### PR TITLE
Make command line fit UNIX expectations

### DIFF
--- a/app.h
+++ b/app.h
@@ -1,5 +1,7 @@
 #define WINDOW_CAPTION "CHIP-8 Machine"
 
+#define NO_OPEN_LOG     1
+#define LOG_FILE_NAME   stderr
 #define EPX_SCALE       0
 #define SCREEN_SCALE    2
 

--- a/render.c
+++ b/render.c
@@ -84,7 +84,7 @@ static void usage() {
                 "  -b bg  : Background color\n"
                 "  -s spd : Specify the speed\n"
                 "  -d     : Debug mode\n"
-                "  -v     : increase verbosity"
+                "  -v     : increase verbosity\n"
                 );
 }
 
@@ -102,16 +102,14 @@ void init_game(int argc, char *argv[]) {
     bg_color = bm_byte_order(bg_color);
 
     int opt;
-    while((opt = getopt(argc, argv, "f:b:s:dv?")) != -1) {
+    while((opt = getopt(argc, argv, "f:b:s:dvh")) != -1) {
         switch(opt) {
             case 'v': c8_verbose++; break;
             case 'f': fg_color = bm_atoi(optarg); break;
             case 'b': bg_color = bm_atoi(optarg); break;
             case 's': speed = atoi(optarg); if(speed < 1) speed = 10; break;
             case 'd': running = 0; break;
-            case '?' : {
-                usage();
-            }
+            case 'h': usage(); break;
         }
     }
 

--- a/sdl/pocadv.c
+++ b/sdl/pocadv.c
@@ -415,6 +415,8 @@ int main(int argc, char *argv[]) {
 	errno_t err = fopen_s(&logfile, LOG_FILE_NAME, "w");
 	if (err != 0)
 		return 1;
+#  elif defined NO_OPEN_LOG
+	logfile = LOG_FILE_NAME;
 #  else
 	logfile = fopen(LOG_FILE_NAME, "w");
 	if (!logfile)


### PR DESCRIPTION
- If the user should read it (i.e. usage message) it should go to `stderr`. Default to `stderr`; if you want to log it, use `tee(1)` or shell redirects.
- Standard output streams don't need to be fopen'd; provide a way to account for that.
- `-?` is a horrible command line operation; it requires quoting. Almost all UNIX users will expect `-h` to work, so use that instead.
- Usage message needs a final newline.