### PR TITLE
I think I'm done

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ README.html
 GAMES
 
 .vscode
+*.ch8

--- a/asmmain.c
+++ b/asmmain.c
@@ -54,7 +54,7 @@ int main(int argc, char *argv[]) {
 
 	c8_reset();
 
-	c8_assemble(text);
+	int return_code = c8_assemble(text);
 
 	if(c8_verbose)
 		printf("Writing output to '%s'...\n", outfile);
@@ -69,5 +69,5 @@ int main(int argc, char *argv[]) {
 	if(c8_verbose)
 		printf("Success.\n");
 
-	return 0;
+	return return_code;
 }

--- a/c8asm.c
+++ b/c8asm.c
@@ -293,7 +293,7 @@ static int evaluate_arithmetic_expression(const char * expression, const int lin
 	*figures.stack=0;figures.top=figures.stack;
 	bool is_prev_figure = true;
 	bool is_first_char_of_clause = true;
-	while (1){
+	while (*expression){
 		int prec;
 		int base;
 
@@ -382,14 +382,13 @@ static int evaluate_arithmetic_expression(const char * expression, const int lin
 						(*figures.top) = apply_unary_op(*operators.top, *figures.top, linenum);
 						operators.top--;
 					}
-					//expression+=len;
 					success=true;
 					is_first_char_of_clause=false;
 					is_prev_figure=true;
 					break;
 				}
 			}
-			if(!success) break;
+			if(!success) exit_error("error%d: Invalid Identifier %s in arithmetic expression\n", linenum,buffer);
 		}
 	}
 

--- a/c8asm.c
+++ b/c8asm.c
@@ -77,32 +77,43 @@ typedef struct {
 	char token[TOK_SIZE];
 } Stepper;
 typedef enum {
-	ET_IMM8,
-	ET_IMM16
+	CONTINUED=0,
+	ET_IMM4=0b10000,
+	ET_IMM8=0b10001,
+	ET_IMM4_EMIT8=0b11000,
+	ET_IMM8_EMIT8=0b11001,
+	ET_IMM12=0b10010,
+	ET_IMM16=0b10011,
+	ET_EXP4=0b10100,
+	ET_EXP8=0b10101,
+	ET_EXP4_EMIT8=0b11100,
+	ET_EXP8_EMIT8=0b11101,
+	ET_EXP12=0b10110,
+	ET_EXP16=0b10111
 } EMITTED_TYPE;
+#define BITNESS_BITMASK 0b0011
+#define EXPRESSION_BITMASK 0b0100
+#define EMIT8_BITMASK 0b1000
+/*
 typedef enum {
 	LT_NONE,
 	LT_FULL
 
-} LABEL_TYPE; 
+} LABEL_TYPE; */
 
 typedef struct {
 	EMITTED_TYPE type;
-	union {
-		uint8_t imm8;
-		uint16_t imm16;	
-	} value;
-	//LABEL_TYPE tlabel;
-	bool is_label;
+	uint16_t value;
 } Emitted;
 
 /* Generated instructions before binary output */
 static struct {
 	struct {
 		uint8_t byte;
-		LABEL_TYPE tlabel;
+		EMITTED_TYPE type;
 		int linenum;
-		char label[TOK_SIZE];
+		char expression[TOK_SIZE];
+		//char label[TOK_SIZE];
 	} bytes[TOTAL_RAM];
 
 	uint16_t next_instr; /* Address of next instruction */
@@ -135,6 +146,27 @@ static void exit_error(const char *msg, ...) {
 	}
 	exit(1);
 }
+static bool is_arith(char c){
+	switch (c){
+		case '0' ... '9':
+		case '(':
+		case '#':
+		case '%':
+		case '+':
+		case '-':
+		case '*':
+		case '/':
+		case '|':
+		case '&':
+		case '^':
+		case '<':
+		case '>':
+		case '~':
+			return true; 
+		default:
+			return false;
+	}
+}
 static bool is_unary_operator(const  char * exp){
 	if ((*exp=='-'||*exp=='+') && exp[1] == '(')
 		return true;
@@ -156,14 +188,13 @@ static int get_precedence(const char * expr){
 		case '|':
 		case '^':
 			return 2;
-		case '#':
-		case '%':
 		case '-':
 		case '+':
-		case '0'...'9':
+	//	case '0'...'9':
 			return 3;
 		case '*':
 		case '/':
+		case '%':
 			return 4;
 		case '(':
 			return 000;
@@ -193,6 +224,7 @@ static int parse_int(const char ** expression,const int linenum){
 		(*expression)++;
 	return (int)strtol(*expression, expression, base);	
 }
+/*
 static void copy_arithmetic_expression(char * buffer, const char ** in){
 	while(1){
 		if (**in == ' '){
@@ -228,10 +260,20 @@ static void copy_arithmetic_expression(char * buffer, const char ** in){
 	}
 	*buffer='\0';
 }
+*/
 
 
+static void copy_arithmetic_expression(char * buffer, const char ** in){
 
-
+	while (**in && **in != ',' && **in !='\n' && **in !=';'){
+		if (**in == ' ') {
+			(*in)++;
+			continue;
+		}
+		(*buffer++)=(*(*in)++);
+	}
+	*buffer='\0';
+}
 
 static  int apply_unary_op (const unsigned char op, const  int val, const int linenum){
 	switch (op)
@@ -265,7 +307,7 @@ static  int apply_binary_op(const  int l_op, const char op, const  int r_op, con
 	case '|':
 		return l_op|r_op;
 	case '&':
-		return l_op|r_op;
+		return l_op&r_op;
 	case '^':
 		return l_op^r_op;
 	case '<':
@@ -288,6 +330,7 @@ static int evaluate_arithmetic_expression(const char * expression, const int lin
 	bool is_first_char_of_clause = true;
 	while (1){
 		int prec;
+		int base;
 
 		if (*expression == ' '){
 			expression++;
@@ -320,11 +363,12 @@ static int evaluate_arithmetic_expression(const char * expression, const int lin
 			is_prev_figure=false;
 			expression++;
 			is_first_char_of_clause=false;
-		} else if ((prec=get_precedence(expression))>0){
+		} else if (((prec=get_precedence(expression))>0) | ((base=get_base(expression))>0)){
 			unsigned char operator_extended[2]={*operators.top,*operators.top};
 			while( 
 				figures.top>=figures.stack &&
 				is_prev_figure && 
+				prec > 0 &&
 				get_precedence((char *)operator_extended)>prec 
 			){
 				const  int r_op = *(figures.top--);
@@ -333,7 +377,7 @@ static int evaluate_arithmetic_expression(const char * expression, const int lin
 				*(++figures.top) = apply_binary_op(l_op, op, r_op,linenum);
 				memset(operator_extended,*operators.top, 2);
 			}
-			if (get_base(expression)>0){
+			if (base>0){
 				if(is_prev_figure) {
 					*(++operators.top)='+';
 				}
@@ -358,17 +402,20 @@ static int evaluate_arithmetic_expression(const char * expression, const int lin
 		} else {
 			bool success = false;
 			for(int i = 0; i < n_lookup; i++) {
-				if(!strcmp(lookup[i].label, expression)) {
+				size_t len = strlen(lookup[i].label);
+				if(!strncmp(lookup[i].label, expression, len)) {
 					if(is_prev_figure) {
 						*(++operators.top)='+';
 					}
 					*(++figures.top)=lookup[i].addr; 
-					is_prev_figure=true;
 					if (*operators.top&0x80){
 						(*figures.top) = apply_unary_op(*operators.top, *figures.top, linenum);
 						operators.top--;
 					}
-					success = true;
+					expression+=len;
+					success=true;
+					is_first_char_of_clause=false;
+					is_prev_figure=true;
 					break;
 				}
 			}
@@ -426,46 +473,39 @@ static void emit_l(const Stepper * stepper, uint16_t inst, LABEL_TYPE tlabel){
 }
 
 */
-static void emit_b(const Stepper * stepper, uint8_t byte, const LABEL_TYPE tlabel) {
+static void emit_b(const Stepper * stepper, uint8_t byte, const EMITTED_TYPE type) {
 	if(program.next_instr >= TOTAL_RAM)
 		exit_error("error: program too large\n");
 	program.bytes[program.next_instr].linenum = stepper->linenum;
-	program.bytes[program.next_instr].tlabel=tlabel;
-	if (tlabel!=LT_NONE) 
-		strcpy(program.bytes[program.next_instr].label, stepper->token);
+	program.bytes[program.next_instr].type=type;
+	if (type&EXPRESSION_BITMASK) 
+		strcpy(program.bytes[program.next_instr].expression, stepper->token);
 	program.bytes[program.next_instr++].byte = byte;
 	if(program.next_instr > program.max_instr)
 		program.max_instr = program.next_instr;
 }
 
 static void emit(const Stepper * stepper, const Emitted emitted){
-	if (emitted.type == ET_IMM16){
-		switch (emitted.tlabel){
-			case LT_NONE:
-			case LT_FULL:
-				emit_b(stepper, emitted.value.imm16>>8, emitted.tlabel);
-				emit_b(stepper, emitted.value.imm16&0xff, LT_NONE);
-			break;
-			/*
-			case LT_HI:
-			case LT_LO:
-				emit_b(stepper, emitted.value.imm16>>8, LT_NONE);
-				emit_b(stepper, emitted.value.imm16&0xff, emitted.tlabel);
-			*/
-			break;
-			
-		}
-
-
+	if (emitted.type==CONTINUED) 
+		exit_error("Continued is reserved\n");
+	else if (emitted.type&EMIT8_BITMASK){
+		emit_b(stepper, emitted.value&0xff, emitted.type);
 	} else {
-		emit_b(stepper, emitted.value.imm8, emitted.tlabel);
+		emit_b(stepper, emitted.value>>8,emitted.type);
+		emit_b(stepper, emitted.value&0xff,CONTINUED);
 	}
 }
 static inline void emit_w(const Stepper * stepper, uint16_t word){
 	const Emitted e = (Emitted){
 		.type=ET_IMM16,
-		.value.imm16=word,
-		.tlabel=LT_NONE
+		.value=word
+	};
+	emit(stepper, e);
+}
+static inline void emit_e(const Stepper * stepper, uint16_t word, size_t nybble_count){
+	const Emitted e = (Emitted){
+		.type=0b10100 | (nybble_count-1),
+		.value=word
 	};
 	emit(stepper, e);
 }
@@ -553,17 +593,27 @@ scan_start:
 				stepper->sym = SYM_DW;
 
 			else {
-				stepper->sym = SYM_IDENTIFIER;
-				for(int i = 0; i < n_defs; i++) {
-					if(!strcmp(defs[i].name, stepper->token)) {
-						stepper->sym = defs[i].type;
-						strcpy(stepper->token, defs[i].value);
-						break;
+				//while (*stepper->in == ' ') stepper->in++;
+				if (is_arith(*stepper->in)){
+					char arith_exp[64];
+					copy_arithmetic_expression(arith_exp, &stepper->in);
+					strcat (stepper->token,arith_exp);
+					stepper->sym=SYM_NUMBER;
+
+				} else {
+					stepper->sym = SYM_IDENTIFIER;
+					for(int i = 0; i < n_defs; i++) {
+						if(!strcmp(defs[i].name, stepper->token)) {
+							stepper->sym = defs[i].type;
+							strcpy(stepper->token, defs[i].value);
+							break;
+						}
 					}
 				}
+				
 			}
 		}
-	} else if(get_base(stepper->in) || is_unary_operator(stepper->in)) {
+	} else if(is_arith(*stepper->in) ) {
 		//sprintf(stepper->token,"%ld",evaluate_arithmetic_expression(&stepper->in, stepper->linenum));
 		copy_arithmetic_expression(stepper->token, &stepper->in);
 		stepper->sym=SYM_NUMBER;
@@ -600,37 +650,18 @@ static int get_register(const Stepper * stepper) {
 	return reg;
 }
 
-static int get_num(const Stepper * stepper, size_t nybble_count) {
-	int a = evaluate_arithmetic_expression(stepper->token, stepper->linenum);
+static int get_num(const char * token, size_t nybble_count, const int linenum) {
+	int a = evaluate_arithmetic_expression(token, linenum);
 	int bound=1<<(4*nybble_count);
 	if(a < -(bound/2) || a > (bound-1)){
-		char format[39];
-		sprintf(format,"error:%%d: invalid addr %%d (%%0%zdX)\n",nybble_count);
-		exit_error(format, stepper->linenum, a, a);
+		char format[128];
+		sprintf(format,"error:%%d: number %%d takes more than %zd nybbles (%%0%zdX)\n",nybble_count,nybble_count);
+		exit_error(format, linenum, a, a);
 	}
 	return a&(bound-1);
 }
-/*
-static int get_byte(const Stepper * stepper) {
-	int a = evaluate_arithmetic_expression(stepper->token, stepper->linenum);
-	if(a < -128 || a > 0xFF)
-		exit_error("error:%d: invalid byte value %d (%02X)\n", stepper->linenum, a, a);
-	return a&0xff;
-}
 
-static int get_word(const Stepper * stepper) {
-	int a = evaluate_arithmetic_expression(stepper->token, stepper->linenum);
-	if(a < 0 || a > 0xFFFF)
-		exit_error("error:%d: invalid word value %d (%04X)\n", stepper->linenum, a, a);
-	return a;
-}
-*/
-bool emit_immediate_instruction(Stepper * stepper, uint16_t base, uint8_t regx){
-	if(stepper->sym == SYM_NUMBER){
-		emit_w(stepper, (base) | (regx << 8) | get_num(stepper,2));
-		return true;
-	}  else return false;
-}
+
 int c8_assemble(const char *text) {
 
 	static Stepper stepper;
@@ -663,9 +694,10 @@ int c8_assemble(const char *text) {
 			if(stepper.sym != SYM_IDENTIFIER)
 				exit_error("error:%d: identifier expected, found %s\n", stepper.linenum, stepper.token);
 			strcpy(name,stepper.token);
-			nextsym(&stepper);
+			nextsym(&stepper); /*
 			if(stepper.sym != SYM_NUMBER && stepper.sym != SYM_REGISTER)
 				exit_error("error:%d: value expected\n", stepper.linenum);
+			*/
 			add_definition(&stepper, name);
 			nextsym(&stepper);
 		}
@@ -674,7 +706,7 @@ int c8_assemble(const char *text) {
 			nextsym(&stepper);
 			if(stepper.sym != SYM_NUMBER)
 				exit_error("error:%d: offset expected\n", stepper.linenum);
-			program.next_instr = get_num(&stepper,3);
+			program.next_instr = get_num(stepper.token,3,stepper.linenum);
 			nextsym(&stepper);
 		break;
 		case SYM_DB:
@@ -684,10 +716,13 @@ int c8_assemble(const char *text) {
 					break;
 				if(stepper.sym != SYM_NUMBER)
 					exit_error("error:%d: byte value expected\n", stepper.linenum);
-				Emitted e={
+				Emitted e={/*
 					.type=ET_IMM8,
 					.value.imm8=get_num(&stepper,2),
-					.tlabel=LT_NONE
+					.tlabel=LT_NONE*/
+					.type=ET_EXP8_EMIT8,
+					.value=0
+
 					
 				};
 
@@ -700,10 +735,9 @@ int c8_assemble(const char *text) {
 				nextsym(&stepper);
 				if(stepper.sym == SYM_END)
 					break;
-				if(stepper.sym != SYM_NUMBER)
+				if(stepper.sym != SYM_NUMBER && stepper.sym != SYM_IDENTIFIER)
 					exit_error("error:%d: byte value expected\n", stepper.linenum);
-				uint16_t word = get_num(&stepper,4);
-				emit_w(&stepper, word);
+				emit_e(&stepper,0, 4);
 				nextsym(&stepper);
 			} while(stepper.sym == ',');
 		break;
@@ -718,11 +752,10 @@ int c8_assemble(const char *text) {
 				emit_w(&stepper, 0x00EE);
 			else if(!strcmp("jp", stepper.token)) {
 				nextsym(&stepper);
-				if(stepper.sym == SYM_IDENTIFIER){
+				if(stepper.sym == SYM_IDENTIFIER || stepper.sym == SYM_NUMBER){
 					const Emitted e={
-						.type=ET_IMM16,
-						.tlabel=LT_FULL,
-						.value.imm16=0x1000
+						.type=ET_EXP16,
+						.value=0x1000
 					};
 					emit(&stepper, e);
 				}
@@ -730,40 +763,35 @@ int c8_assemble(const char *text) {
 					if(strcmp(stepper.token, "v0"))
 						exit_error("error:%d: JP applies to V0 only\n", stepper.linenum);
 					expect(&stepper, ',');
-					if(stepper.sym == SYM_IDENTIFIER){
+					if(stepper.sym == SYM_IDENTIFIER || stepper.sym == SYM_NUMBER){
 						const Emitted e={
-							.type=ET_IMM16,
-							.tlabel=LT_FULL,
-							.value.imm16=0xB000
+							.type=ET_EXP16,
+							.value=0xB000
 						};
 						emit(&stepper, e);
 					}
 					else
-						emit_w(&stepper, 0xB000 | get_num(&stepper,3));
+						emit_e(&stepper, 0xB000 ,3);
 				} else
-					emit_w(&stepper, 0x1000 | get_num(&stepper,3));
+					emit_e(&stepper, 0x1000 , 3);
 			} else if(!strcmp("call", stepper.token)) {
 				nextsym(&stepper);
-				if(stepper.sym == SYM_IDENTIFIER){
-					const Emitted e={
-						.type=ET_IMM16,
-						.tlabel=LT_FULL,
-						.value.imm16=0x2000
-					};
-					emit(&stepper, e);
+				if(stepper.sym != SYM_IDENTIFIER && stepper.sym != SYM_NUMBER){
+					exit_error("error:%d: address expected", stepper.linenum);
 				}
-				else {
-					if(stepper.sym != SYM_NUMBER)
-						exit_error("error:%d: address expected", stepper.linenum);
-					emit_w(&stepper, 0x2000 | get_num(&stepper,3));
-				}
+				const Emitted e={
+					.type=ET_EXP16,
+					.value=0x2000
+				};
+				emit(&stepper, e);
+				
 			} else if(!strcmp("se", stepper.token)) {
 				nextsym(&stepper);
 				int regx = get_register(&stepper);
 				expect(&stepper, ',');
-				if(stepper.sym == SYM_NUMBER)
-					emit_w(&stepper, 0x3000 | (regx << 8) | get_num(&stepper,2));
-				 else if(stepper.sym == SYM_REGISTER) {
+				if(stepper.sym == SYM_NUMBER || stepper.sym == SYM_IDENTIFIER)
+					emit_e(&stepper, 0x3000 | (regx << 8), 2);
+				else if(stepper.sym == SYM_REGISTER) {
 					int regy = get_register(&stepper);
 					emit_w(&stepper, 0x5000 | (regx << 8) | (regy << 4));
 				} else
@@ -772,8 +800,8 @@ int c8_assemble(const char *text) {
 				nextsym(&stepper);
 				int regx = get_register(&stepper);
 				expect(&stepper, ',');
-				if(stepper.sym == SYM_NUMBER)
-					emit_w(&stepper, 0x4000 | (regx << 8) | get_num(&stepper,2));
+				if(stepper.sym == SYM_NUMBER || stepper.sym==SYM_IDENTIFIER)
+					emit_e(&stepper, 0x4000 | (regx << 8) ,2);
 				else if(stepper.sym == SYM_REGISTER) {
 					int regy = get_register(&stepper);
 					emit_w(&stepper, 0x9000 | (regx << 8) | (regy << 4));
@@ -787,8 +815,8 @@ int c8_assemble(const char *text) {
 				} else {
 					int regx = get_register(&stepper);
 					expect(&stepper, ',');
-					if(stepper.sym == SYM_NUMBER)
-						emit_w(&stepper, 0x7000 | (regx << 8) | get_num(&stepper,2));
+					if(stepper.sym == SYM_NUMBER || stepper.sym == SYM_IDENTIFIER)
+						emit_e(&stepper, 0x7000 | (regx << 8) ,2);
 					 else if(stepper.sym == SYM_REGISTER) {
 						int regy = get_register(&stepper);
 						emit_w(&stepper, 0x8004 | (regx << 8) | (regy << 4));
@@ -799,15 +827,14 @@ int c8_assemble(const char *text) {
 				nextsym(&stepper);
 				if(stepper.sym == SYM_I) {
 					expect(&stepper, ',');
-					if(stepper.sym == SYM_IDENTIFIER){
+					if(stepper.sym == SYM_IDENTIFIER || stepper.sym == SYM_NUMBER){
 						const Emitted e={
-							.type=ET_IMM16,
-							.tlabel=LT_FULL,
-							.value.imm16=0xA000
+							.type=ET_EXP16,
+							.value=0xA000
 						};
 						emit(&stepper, e);
 					} else
-						emit_w(&stepper, 0xA000 | get_num(&stepper,3));
+						emit_e(&stepper, 0xA000,3);
 				} else if(stepper.sym == SYM_DT) {
 					expect(&stepper, ',');
 					emit_w(&stepper, 0xF015 | (get_register(&stepper) << 8));
@@ -836,8 +863,8 @@ int c8_assemble(const char *text) {
 				} else {
 					int regx = get_register(&stepper);
 					expect(&stepper, ',');
-					if(stepper.sym == SYM_NUMBER)
-						emit_w(&stepper, 0x6000 | (regx << 8) | get_num(&stepper, 2));
+					if(stepper.sym == SYM_NUMBER || stepper.sym == SYM_IDENTIFIER)
+						emit_e(&stepper, 0x6000 | (regx << 8) , 2);
 					 else if(stepper.sym == SYM_REGISTER) {
 						int regy = get_register(&stepper);
 						emit_w(&stepper, 0x8000 | (regx << 8) | (regy << 4));
@@ -911,8 +938,8 @@ int c8_assemble(const char *text) {
 				nextsym(&stepper);
 				int regx = get_register(&stepper);
 				expect(&stepper, ',');
-				if(stepper.sym == SYM_NUMBER){
-					emit_w(&stepper, 0xC000 | (regx << 8) | get_num(&stepper,2));
+				if(stepper.sym == SYM_NUMBER || stepper.sym == SYM_IDENTIFIER){
+					emit_e(&stepper, 0xC000 | (regx << 8) ,2);
 				}
 				else exit_error("error:%d: operand expected\n", stepper.linenum);
 			}  else if(!strcmp("drw", stepper.token)) {
@@ -921,7 +948,7 @@ int c8_assemble(const char *text) {
 				expect(&stepper, ',');
 				int regy = get_register(&stepper);
 				expect(&stepper, ',');
-				emit_w(&stepper, 0xD000 | (regx << 8) | (regy << 4) | get_num(&stepper,1));
+				emit_e(&stepper, 0xD000 | (regx << 8) | (regy << 4),1);
 			} else if(!strcmp("skp", stepper.token)) {
 				nextsym(&stepper);
 				emit_w(&stepper, 0xE09E | (get_register(&stepper) << 8));
@@ -930,7 +957,7 @@ int c8_assemble(const char *text) {
 				emit_w(&stepper, 0xE0A1 | (get_register(&stepper) << 8));
 			} else if(!strcmp("scd", stepper.token)) {
 				nextsym(&stepper);
-				emit_w(&stepper, 0x00C0 | get_num(&stepper,1));
+				emit_e(&stepper, 0x00C0 ,1);
 			} else if(!strcmp("scr", stepper.token)) {
 				emit_w(&stepper, 0x00FB);
 			} else if(!strcmp("scl", stepper.token)) {
@@ -943,7 +970,7 @@ int c8_assemble(const char *text) {
 				emit_w(&stepper, 0x00FF);
 			} else if(!strcmp("sys", stepper.token)) {
 				nextsym(&stepper);
-				emit_w(&stepper, 0x0000 | get_num(&stepper,3));
+				emit_e(&stepper, 0x0000,3);
 			}
 
 			nextsym(&stepper);
@@ -957,35 +984,21 @@ int c8_assemble(const char *text) {
 	size_t n = PROG_OFFSET;
 	bool success=false;
 	for(int i = PROG_OFFSET; i < program.max_instr; i++) {
-		if(program.bytes[i].tlabel) {
-			for(int j = 0; j < n_lookup; j++) {
-				if(!strcmp(lookup[j].label, program.bytes[i].label)) {
-					assert(lookup[j].addr <= 0xFFF);
-					switch (program.bytes[i].tlabel)
-					{
-						case LT_FULL:
-						program.bytes[i].byte |= (lookup[j].addr >> 8);
-						program.bytes[i + 1].byte = lookup[j].addr & 0xFF;
-						break;  
-						/* 
-						case LT_HI:
-						program.bytes[i].byte = (lookup[j].addr >> 8);
-						break;
-						case LT_LO:
-						program.bytes[i].byte = lookup[j].addr & 0xFF;
-						*/
-						case LT_NONE:
-						/*to prevent the compiler from complaining*/
-						break;
+		uint16_t result=0;
+		if(program.bytes[i].type & EXPRESSION_BITMASK) {
+			result = get_num(program.bytes[i].expression, (program.bytes[i].type & BITNESS_BITMASK)+1,program.bytes[i].linenum);
 
-					}
-					success=true;
-					break;
-				}
-			}
-			if(!success)
-				exit_error("error:%d: unresolved label '%s'\n", program.bytes[i].linenum, program.bytes[i].label);
 		}
+		if (program.bytes[i].type & EMIT8_BITMASK) {
+			program.bytes[i].byte |= result &0xff;
+		} else {
+			program.bytes[i].byte |= result >> 8;
+			program.bytes[i+1].byte |= result & 0xff;
+		}
+
+
+		 
+
 		if(c8_verbose > 1) {
 			if(!(i & 0x01))
 				c8_message("%03X: %02X", i, program.bytes[i].byte);
@@ -994,6 +1007,10 @@ int c8_assemble(const char *text) {
 		}
 
 		c8_set(n++, program.bytes[i].byte);
+	}
+	//Stupid Off by one
+	if (program.max_instr < TOTAL_RAM && program.bytes[program.max_instr].byte != 0){
+		c8_set(n++, program.bytes[program.max_instr].byte);
 	}
 	if(c8_verbose > 1 && success)
 		c8_message("\n");

--- a/c8asm.c
+++ b/c8asm.c
@@ -93,7 +93,7 @@ static uint16_t max_instr;  /* Largest instruction address for output */
 
 /* Lookup table for labels for JP and CALL instructions */
 static struct {
-    char *label;
+    char label[TOK_SIZE];
     uint16_t addr;
 } lookup[MAX_LOOKUP];
 static int n_lookup;
@@ -102,7 +102,7 @@ static int n_lookup;
 static struct {
     char *name;
     SYMBOL type;
-    char *value;
+    char value[TOK_SIZE];
 } defs[MAX_DEFS];
 static int n_defs;
 
@@ -134,7 +134,7 @@ static void emit_l(const Stepper * stepper, uint16_t inst, const char *label) {
         exit_error("error: program too large\n");
     program[next_instr].linenum = stepper->linenum;
     program[next_instr].byte = inst >> 8;
-    program[next_instr].label = strdup(label);
+    strcpy(program[next_instr].label, label);
     next_instr++;
     program[next_instr].linenum = stepper->linenum;
     program[next_instr].byte = 0;
@@ -159,7 +159,7 @@ static void add_label(const char *label, const int linenum) {
     for(i = 0; i < n_lookup; i++)
         if(!strcmp(lookup[i].label, label))
             exit_error("error:%d: duplicate label '%s'\n", linenum, label);
-    lookup[n_lookup].label = strdup(label);
+    strcpy(lookup[n_lookup].label, label);
     lookup[n_lookup].addr = next_instr;
     n_lookup++;
 }
@@ -169,7 +169,7 @@ static void add_definition(const Stepper * stepper, char *name) {
         exit_error("error:%d: too many definitions\n", stepper->linenum);
     defs[n_defs].name = name;
     defs[n_defs].type = stepper->sym;
-    defs[n_defs].value = strdup(stepper->token);
+    strcpy(defs[n_defs].value,stepper->token);
     n_defs++;
 }
 
@@ -361,13 +361,13 @@ int c8_assemble(const char *text) {
         //c8_message("%d %d %s\n", stepper.linenum, stepper.sym, stepper->token);
         if(stepper.sym == SYM_DEFINE) {
             nextsym(&stepper);
-            char *name;
+            char * name;
             /* "Identifier expected" may also mean that the name has
                 already been used, eg. if aaa is already defined as 123
                 then define aaa 456 looks like define 123 456 */
             if(stepper.sym != SYM_IDENTIFIER)
                 exit_error("error:%d: identifier expected, found %s\n", stepper.linenum, stepper.token);
-            name = strdup(stepper.token);
+            name=stepper.token;
             nextsym(&stepper);
             if(stepper.sym != SYM_NUMBER && stepper.sym != SYM_REGISTER)
                 exit_error("error:%d: value expected\n", stepper.linenum);
@@ -648,7 +648,7 @@ int c8_assemble(const char *text) {
                     assert(lookup[j].addr <= 0xFFF);
                     program[i].byte |= (lookup[j].addr >> 8);
                     program[i + 1].byte = lookup[j].addr & 0xFF;
-                    free(program[i].label);
+                    //free(program[i].label);
                     program[i].label = NULL;
                     break;
                 }
@@ -669,7 +669,7 @@ int c8_assemble(const char *text) {
         c8_message("\n");
 
     if(c8_verbose) c8_message("Assembled; %d bytes.\n", max_instr - PROG_OFFSET);
-
+    /*
     for(i = 0; i < n_lookup; i++) {
         free(lookup[i].label);
     }
@@ -677,6 +677,6 @@ int c8_assemble(const char *text) {
         free(defs[i].name);
         free(defs[i].value);
     }
-
+    */
     return 1;
 }

--- a/c8asm.c
+++ b/c8asm.c
@@ -166,10 +166,10 @@ static long int evaluate_arithmetic_expression(const char ** expression, char se
 			if ((*expression)[1] == '('){
 				if (**expression == '-'){
 					(*expression)+=2;
-					high_prec_value -= evaluate_arithmetic_expression(expression, ')');
+					high_prec_value = evaluate_arithmetic_expression(expression, ')');
 				 } else if (**expression == '+'){
 					(*expression)+=2;
-					high_prec_value += evaluate_arithmetic_expression(expression, ')');
+					high_prec_value = evaluate_arithmetic_expression(expression, ')');
 
 				 }
 				else	
@@ -194,11 +194,9 @@ static long int evaluate_arithmetic_expression(const char ** expression, char se
 					divisor = evaluate_arithmetic_expression(expression, ')');
 				} else 
 					divisor = parse_int(expression);
-				if (high_prec_value == 0){
-					high_prec_value=divisor;
-				} else if (divisor == 0 ){
+				if (divisor == 0){
 						exit_error("Divide by 0\n");
-				} else {	
+				} else {
 					high_prec_value /= divisor;
 				}
 			} else if (**expression == '('){

--- a/c8asm.c
+++ b/c8asm.c
@@ -76,6 +76,10 @@ typedef struct {
 	int linenum;
 	char token[TOK_SIZE];
 } Stepper;
+
+#define BITNESS_BITMASK 0b0011
+#define EXPRESSION_BITMASK 0b0100
+#define EMIT8_BITMASK 0b1000
 typedef enum {
 	CONTINUED=0,
 	ET_IMM4=0b10000,
@@ -91,9 +95,6 @@ typedef enum {
 	ET_EXP12=0b10110,
 	ET_EXP16=0b10111
 } EMITTED_TYPE;
-#define BITNESS_BITMASK 0b0011
-#define EXPRESSION_BITMASK 0b0100
-#define EMIT8_BITMASK 0b1000
 /*
 typedef enum {
 	LT_NONE,
@@ -436,7 +437,7 @@ static inline void emit_w(const Stepper * stepper, uint16_t word){
 }
 static inline void emit_e(const Stepper * stepper, uint16_t word, size_t nybble_count){
 	const Emitted e = (Emitted){
-		.type=0b10100 | (nybble_count-1),
+		.type=0b10000 | EXPRESSION_BITMASK | (nybble_count-1),
 		.value=word
 	};
 	emit(stepper, e);

--- a/c8asm.c
+++ b/c8asm.c
@@ -22,672 +22,676 @@ Hexadecimal constants can be written as
 #define MAX_LOOKUP  256
 
 typedef enum {
-    SYM_END,
-    SYM_IDENTIFIER,
-    SYM_INSTRUCTION,
-    SYM_REGISTER,
-    SYM_NUMBER,
-    SYM_I,
-    SYM_DT,
-    SYM_ST,
-    SYM_K,
-    SYM_F,
-    SYM_B,
-    SYM_HF,
-    SYM_R,
-    SYM_DEFINE,
-    SYM_OFFSET,
-    SYM_DB,
-    SYM_DW,
-    SYM_HI,
-    SYM_LO
+	SYM_END,
+	SYM_IDENTIFIER,
+	SYM_INSTRUCTION,
+	SYM_REGISTER,
+	SYM_NUMBER,
+	SYM_I,
+	SYM_DT,
+	SYM_ST,
+	SYM_K,
+	SYM_F,
+	SYM_B,
+	SYM_HF,
+	SYM_R,
+	SYM_DEFINE,
+	SYM_OFFSET,
+	SYM_DB,
+	SYM_DW,
+	SYM_HI,
+	SYM_LO
 } SYMBOL;
 /* List of instruction names. */
 static const char *inst_names[] = {
-    "add",
-    "and",
-    "call",
-    "cls",
-    "drw",
-    "jp",
-    "ld",
-    "or",
-    "ret",
-    "rnd",
-    "se",
-    "shl",
-    "shr",
-    "sknp",
-    "skp",
-    "sne",
-    "sub",
-    "subn",
-    "sys",
-    "xor",
-    "scd",
-    "scr",
-    "scl",
-    "exit",
-    "lo",
-    "hi",
+	"add",
+	"and",
+	"call",
+	"cls",
+	"drw",
+	"jp",
+	"ld",
+	"or",
+	"ret",
+	"rnd",
+	"se",
+	"shl",
+	"shr",
+	"sknp",
+	"skp",
+	"sne",
+	"sub",
+	"subn",
+	"sys",
+	"xor",
+	"scd",
+	"scr",
+	"scl",
+	"exit"
 };
 
 //static int sym;
 typedef struct {
-    const char * in;
-    const char * last;
-    SYMBOL sym;
-    int linenum;
-    char token[TOK_SIZE];
+	const char * in;
+	const char * last;
+	SYMBOL sym;
+	int linenum;
+	char token[TOK_SIZE];
 } Stepper;
 
+typedef enum {
+	LT_NONE,
+	LT_FULL,
+	LT_HI,
+	LT_LO
 
+} LABEL_TYPE; 
 /* Generated instructions before binary output */
 static struct {
-    struct {
-        uint8_t byte;
-        char label[TOK_SIZE];
-        int linenum;
-    } bytes[TOTAL_RAM];
+	struct {
+		uint8_t byte;
+		LABEL_TYPE tlabel;
+		char label[TOK_SIZE];
+		int linenum;
+	} bytes[TOTAL_RAM];
 
-    uint16_t next_instr; /* Address of next instruction */
-    uint16_t max_instr;  /* Largest instruction address for output */
+	uint16_t next_instr; /* Address of next instruction */
+	uint16_t max_instr;  /* Largest instruction address for output */
 } program;
 
 /* Lookup table for labels for JP and CALL instructions */
 static struct {
-    char label[TOK_SIZE];
-    uint16_t addr;
+	char label[TOK_SIZE];
+	uint16_t addr;
 } lookup[MAX_LOOKUP];
 static int n_lookup;
 
 /* Lookup table for DEFINE identifier value statements */
 static struct {
-    char name[TOK_SIZE];
-    SYMBOL type;
-    char value[TOK_SIZE];
+	char name[TOK_SIZE];
+	SYMBOL type;
+	char value[TOK_SIZE];
 } defs[MAX_DEFS];
 static int n_defs;
 
 static void exit_error(const char *msg, ...) {
-    char buffer[MAX_MESSAGE_TEXT];
-    if(msg) {
-        va_list arg;
-        va_start (arg, msg);
-        vsnprintf (buffer, MAX_MESSAGE_TEXT - 1, msg, arg);
-        va_end (arg);
-        c8_message("%s", buffer);
-    }
-    exit(1);
+	char buffer[MAX_MESSAGE_TEXT];
+	if(msg) {
+		va_list arg;
+		va_start (arg, msg);
+		vsnprintf (buffer, MAX_MESSAGE_TEXT - 1, msg, arg);
+		va_end (arg);
+		c8_message("%s", buffer);
+	}
+	exit(1);
 }
 static void emit_b(const Stepper * stepper, uint8_t byte) {
-    if(program.next_instr >= TOTAL_RAM)
-        exit_error("error: program too large\n");
-    program.bytes[program.next_instr].linenum = stepper->linenum;
-    program.bytes[program.next_instr++].byte = byte;
-    if(program.next_instr > program.max_instr)
-        program.max_instr = program.next_instr;
+	if(program.next_instr >= TOTAL_RAM)
+		exit_error("error: program too large\n");
+	program.bytes[program.next_instr].linenum = stepper->linenum;
+	program.bytes[program.next_instr++].byte = byte;
+	if(program.next_instr > program.max_instr)
+		program.max_instr = program.next_instr;
 }
 
 static inline void emit(const Stepper * stepper, uint16_t inst) {
-    emit_b(stepper, inst >> 8);
-    emit_b(stepper, inst & 0xFF);
+	emit_b(stepper, inst >> 8);
+	emit_b(stepper, inst & 0xFF);
 }
-/*
-static void emit_l(const Stepper * stepper, uint16_t inst) {
-    if(next_instr == TOTAL_RAM)
-        exit_error("error: program too large\n");
-    program[next_instr].linenum = stepper->linenum;
-    program[next_instr].byte = inst >> 8;
-    strcpy(program[next_instr].label, stepper->token);
-    next_instr++;
-    program[next_instr].linenum = stepper->linenum;
-    program[next_instr].byte = 0;
-    next_instr++;
-    if(next_instr > max_instr)
-        max_instr = next_instr;
+static void emit_lb(const Stepper * stepper, LABEL_TYPE tlabel){
+	if(program.next_instr >= TOTAL_RAM)
+		exit_error("error: program too large\n");
+	program.bytes[program.next_instr].linenum = stepper->linenum;
+	strcpy(program.bytes[program.next_instr].label, stepper->token);
+	program.bytes[program.next_instr].tlabel=tlabel;
+	program.bytes[program.next_instr++].byte = 0;
+	if(program.next_instr > program.max_instr)
+		program.max_instr = program.next_instr;
 }
-*/
-static inline void emit_l(const Stepper * stepper, uint16_t inst){
-    strcpy(program.bytes[program.next_instr].label, stepper->token);
-    emit(stepper, inst & 0xf000);
-
+static void emit_l(const Stepper * stepper, uint16_t inst, LABEL_TYPE tlabel){
+	if (tlabel == LT_NONE){
+		exit_error("emit_l called on NONE label\n");
+	} else if (tlabel == LT_FULL){
+		strcpy(program.bytes[program.next_instr].label, stepper->token);
+		program.bytes[program.next_instr].tlabel=LT_FULL;
+		emit(stepper, inst & 0xf000);
+	} else {
+		emit_b(stepper, inst>>8);
+		emit_lb(stepper, tlabel);
+	}
 }
 
 
 static void add_label(const char *label, const int linenum) {
-    if(n_lookup == MAX_LOOKUP)
-        exit_error("error: too many entries in lookup\n");
-    for(int i = 0; i < n_lookup; i++)
-        if(!strcmp(lookup[i].label, label))
-            exit_error("error:%d: duplicate label '%s'\n", linenum, label);
-    strcpy(lookup[n_lookup].label, label);
-    lookup[n_lookup].addr = program.next_instr;
-    n_lookup++;
+	if(n_lookup == MAX_LOOKUP)
+		exit_error("error: too many entries in lookup\n");
+	for(int i = 0; i < n_lookup; i++)
+		if(!strcmp(lookup[i].label, label))
+			exit_error("error:%d: duplicate label '%s'\n", linenum, label);
+	strcpy(lookup[n_lookup].label, label);
+	lookup[n_lookup].addr = program.next_instr;
+	n_lookup++;
 }
 
 static void add_definition(const Stepper * stepper, char *name) {
-    if(n_defs == MAX_DEFS)
-        exit_error("error:%d: too many definitions\n", stepper->linenum);
-    strcpy(defs[n_defs].name, name);
-    defs[n_defs].type = stepper->sym;
-    strcpy(defs[n_defs].value,stepper->token);
-    n_defs++;
+	if(n_defs == MAX_DEFS)
+		exit_error("error:%d: too many definitions\n", stepper->linenum);
+	strcpy(defs[n_defs].name, name);
+	defs[n_defs].type = stepper->sym;
+	strcpy(defs[n_defs].value,stepper->token);
+	n_defs++;
 }
 
 static int nextsym(Stepper * stepper) {
-    /* TODO: Ought to guard against buffer overruns in tok, but not today. */
-    char *tok = stepper->token;
+	/* TODO: Ought to guard against buffer overruns in tok, but not today. */
+	char *tok = stepper->token;
 
-    stepper->sym = SYM_END;
-    *tok = '\0';
+	stepper->sym = SYM_END;
+	*tok = '\0';
 
 scan_start:
-    while(isspace(*stepper->in)) {
-        if(*stepper->in == '\n')
-            stepper->linenum++;
-        stepper->in++;
-    }
+	while(isspace(*stepper->in)) {
+		if(*stepper->in == '\n')
+			stepper->linenum++;
+		stepper->in++;
+	}
 
-    stepper->last=stepper->in;
-    if(!*stepper->in)
-        return SYM_END;
+	stepper->last=stepper->in;
+	if(!*stepper->in)
+		return SYM_END;
 
-    if(*stepper->in == ';') {
-        while(*stepper->in && *stepper->in != '\n')
-            stepper->in++;
-        goto scan_start;
-    }
-    
+	if(*stepper->in == ';') {
+		while(*stepper->in && *stepper->in != '\n')
+			stepper->in++;
+		goto scan_start;
+	}
+	
 
-    if(isalpha(*stepper->in)) {
-        while(isalnum(*stepper->in) || *stepper->in == '_')
-            *tok++ = tolower(*stepper->in++);
-        *tok = '\0';
-        for(int i = 0; i < (sizeof inst_names)/(sizeof inst_names[0]); i++)
-            if(!strcmp(inst_names[i], stepper->token)) {
-                stepper->sym = SYM_INSTRUCTION;
-                break;
-            }
+	if(isalpha(*stepper->in)) {
+		while(isalnum(*stepper->in) || *stepper->in == '_')
+			*tok++ = tolower(*stepper->in++);
+		*tok = '\0';
+		for(int i = 0; i < (sizeof inst_names)/(sizeof inst_names[0]); i++)
+			if(!strcmp(inst_names[i], stepper->token)) {
+				stepper->sym = SYM_INSTRUCTION;
+				break;
+			}
 
-        if(stepper->sym != SYM_INSTRUCTION) {
-            if(stepper->token[0] == 'v' && isxdigit(stepper->token[1]) && !stepper->token[2])
-                stepper->sym = SYM_REGISTER;
-            else if(!strcmp(stepper->token, "i"))
-                stepper->sym = SYM_I;
-            else if(!strcmp(stepper->token, "dt"))
-                stepper->sym = SYM_DT;
-            else if(!strcmp(stepper->token, "st"))
-                stepper->sym = SYM_ST;
-            else if(!strcmp(stepper->token, "k"))
-                stepper->sym = SYM_K;
-            else if(!strcmp(stepper->token, "f"))
-                stepper->sym = SYM_F;
-            else if(!strcmp(stepper->token, "b"))
-                stepper->sym = SYM_B;
-            else if(!strcmp(stepper->token, "hf"))
-                stepper->sym = SYM_HF;
-            else if(!strcmp(stepper->token, "r"))
-                stepper->sym = SYM_R;
-            else if(!strcmp(stepper->token, "define"))
-                stepper->sym = SYM_DEFINE;
-            else if(!strcmp(stepper->token, "offset"))
-                stepper->sym = SYM_OFFSET;
-            else if(!strcmp(stepper->token, "db"))
-                stepper->sym = SYM_DB;
-            else if(!strcmp(stepper->token, "dw"))
-                stepper->sym = SYM_DW;
-            else if(!strcmp(stepper->token, "hi"))
-                stepper->sym = SYM_HI;
-            else if(!strcmp(stepper->token, "lo"))
-                stepper->sym = SYM_LO;
+		if(stepper->sym != SYM_INSTRUCTION) {
+			if(stepper->token[0] == 'v' && isxdigit(stepper->token[1]) && !stepper->token[2])
+				stepper->sym = SYM_REGISTER;
+			else if(!strcmp(stepper->token, "i"))
+				stepper->sym = SYM_I;
+			else if(!strcmp(stepper->token, "dt"))
+				stepper->sym = SYM_DT;
+			else if(!strcmp(stepper->token, "st"))
+				stepper->sym = SYM_ST;
+			else if(!strcmp(stepper->token, "k"))
+				stepper->sym = SYM_K;
+			else if(!strcmp(stepper->token, "f"))
+				stepper->sym = SYM_F;
+			else if(!strcmp(stepper->token, "b"))
+				stepper->sym = SYM_B;
+			else if(!strcmp(stepper->token, "hf"))
+				stepper->sym = SYM_HF;
+			else if(!strcmp(stepper->token, "r"))
+				stepper->sym = SYM_R;
+			else if(!strcmp(stepper->token, "define"))
+				stepper->sym = SYM_DEFINE;
+			else if(!strcmp(stepper->token, "offset"))
+				stepper->sym = SYM_OFFSET;
+			else if(!strcmp(stepper->token, "db"))
+				stepper->sym = SYM_DB;
+			else if(!strcmp(stepper->token, "dw"))
+				stepper->sym = SYM_DW;
+			else if(!strcmp(stepper->token, "hi"))
+				stepper->sym = SYM_HI;
+			else if(!strcmp(stepper->token, "lo"))
+				stepper->sym = SYM_LO;
 
-            else {
-                stepper->sym = SYM_IDENTIFIER;
-                for(int i = 0; i < n_defs; i++) {
-                    if(!strcmp(defs[i].name, stepper->token)) {
-                        stepper->sym = defs[i].type;
-                        strcpy(stepper->token, defs[i].value);
-                        break;
-                    }
-                }
-            }
-        }
-    } else if(isdigit(*stepper->in) || *stepper->in=='-' || *stepper->in=='+') {
-        *tok++ = *stepper->in++;
-        while(isdigit(*stepper->in))
-            *tok++ = *stepper->in++;
-        if(isalnum(*stepper->in))
-            exit_error("error:%d: invalid number\n", stepper->linenum);
-        *tok = '\0';
-        stepper->sym = SYM_NUMBER;
-    } else if(*stepper->in == '#') {
-        stepper->in++;
-        while(isxdigit(*stepper->in))
-            *tok++ = *stepper->in++;
-        if(isalnum(*stepper->in))
-            exit_error("error:%d: invalid #hex number\n", stepper->linenum);
-        *tok = '\0';
-        long x = strtol(stepper->token, NULL, 16);
-        sprintf(stepper->token, "%ld", x);
-        stepper->sym = SYM_NUMBER;
-    } else if(*stepper->in == '%') {
-        stepper->in++;
-        while(strchr("01",*stepper->in))
-            *tok++ = *stepper->in++;
-        if(isalnum(*stepper->in))
-            exit_error("error:%d: invalid %%bin number\n", stepper->linenum);
-        *tok = '\0';
-        long x = strtol(stepper->token, NULL, 2);
-        sprintf(stepper->token, "%ld", x);
-        stepper->sym = SYM_NUMBER;
-    } else {
-        stepper->token[0] = *stepper->in;
-        stepper->token[1] = '\0';
-        stepper->sym = *stepper->in++;
-    }
+			else {
+				stepper->sym = SYM_IDENTIFIER;
+				for(int i = 0; i < n_defs; i++) {
+					if(!strcmp(defs[i].name, stepper->token)) {
+						stepper->sym = defs[i].type;
+						strcpy(stepper->token, defs[i].value);
+						break;
+					}
+				}
+			}
+		}
+	} else if(isdigit(*stepper->in) || *stepper->in=='-' || *stepper->in=='+') {
+		*tok++ = *stepper->in++;
+		while(isdigit(*stepper->in))
+			*tok++ = *stepper->in++;
+		if(isalnum(*stepper->in))
+			exit_error("error:%d: invalid number\n", stepper->linenum);
+		*tok = '\0';
+		stepper->sym = SYM_NUMBER;
+	} else if(*stepper->in == '#') {
+		stepper->in++;
+		while(isxdigit(*stepper->in))
+			*tok++ = *stepper->in++;
+		if(isalnum(*stepper->in))
+			exit_error("error:%d: invalid #hex number\n", stepper->linenum);
+		*tok = '\0';
+		long x = strtol(stepper->token, NULL, 16);
+		sprintf(stepper->token, "%ld", x);
+		stepper->sym = SYM_NUMBER;
+	} else if(*stepper->in == '%') {
+		stepper->in++;
+		while(strchr("01",*stepper->in))
+			*tok++ = *stepper->in++;
+		if(isalnum(*stepper->in))
+			exit_error("error:%d: invalid %%bin number\n", stepper->linenum);
+		*tok = '\0';
+		long x = strtol(stepper->token, NULL, 2);
+		sprintf(stepper->token, "%ld", x);
+		stepper->sym = SYM_NUMBER;
+	} else {
+		stepper->token[0] = *stepper->in;
+		stepper->token[1] = '\0';
+		stepper->sym = *stepper->in++;
+	}
 
-    return stepper->sym;
+	return stepper->sym;
 }
 
 
 
 
 void expect(Stepper * stepper, int what) {
-    SYMBOL sym = nextsym(stepper); 
-    if(sym != what) 
-        exit_error("error:%d: '%c'%d expected\n", stepper->linenum, what,sym); 
-    nextsym(stepper);
+	SYMBOL sym = nextsym(stepper); 
+	if(sym != what) 
+		exit_error("error:%d: '%c'%d expected\n", stepper->linenum, what,sym); 
+	nextsym(stepper);
 }
 
 static int get_register(const Stepper * stepper) {
-    int reg = stepper->token[1];
-    if(stepper->sym != SYM_REGISTER){
-        printf("%s\n", stepper->token);
-        exit_error("error:%d: register expected\n", stepper->linenum);
-    }
-    assert(isxdigit(reg));
-    if(reg >= 'a') {
-        reg = reg - 'a' + 0xA;
-    } else {
-        reg -= '0';
-    }
-    assert(reg >= 0 && reg <= 0xF);
-    return reg;
+	int reg = stepper->token[1];
+	if(stepper->sym != SYM_REGISTER)
+		exit_error("error:%d: register expected\n", stepper->linenum);
+	assert(isxdigit(reg));
+	if(reg >= 'a') {
+		reg = reg - 'a' + 0xA;
+	} else {
+		reg -= '0';
+	}
+	assert(reg >= 0 && reg <= 0xF);
+	return reg;
 }
 
 static int get_addr(const Stepper * stepper) {
-    int a = atoi(stepper->token);
-    if(a < 0 || a > 0xFFF)
-        exit_error("error:%d: invalid addr %d (%03X)\n", stepper->linenum, a, a);
-    return a;
+	int a = atoi(stepper->token);
+	if(a < 0 || a > 0xFFF)
+		exit_error("error:%d: invalid addr %d (%03X)\n", stepper->linenum, a, a);
+	return a;
 }
 
 static int get_byte(const Stepper * stepper) {
-    int a = atoi(stepper->token);
-    if(a < -128 || a > 0xFF)
-        exit_error("error:%d: invalid byte value %d (%02X)\n", stepper->linenum, a, a);
-    return a&0xff;
+	int a = atoi(stepper->token);
+	if(a < -128 || a > 0xFF)
+		exit_error("error:%d: invalid byte value %d (%02X)\n", stepper->linenum, a, a);
+	return a&0xff;
 }
 
 static int get_word(const Stepper * stepper) {
-    int a = atoi(stepper->token);
-    if(a < 0 || a > 0xFFFF)
-        exit_error("error:%d: invalid word value %d (%04X)\n", stepper->linenum, a, a);
-    return a;
+	int a = atoi(stepper->token);
+	if(a < 0 || a > 0xFFFF)
+		exit_error("error:%d: invalid word value %d (%04X)\n", stepper->linenum, a, a);
+	return a;
 }
 
 int c8_assemble(const char *text) {
 
-    static Stepper stepper;
-    stepper.in = text;
+	static Stepper stepper;
+	stepper.in = text;
 
-    if(c8_verbose) c8_message("Assembling...\n");
+	if(c8_verbose) c8_message("Assembling...\n");
 
-    program.next_instr = 512;
-    program.max_instr = 0;
 
-    stepper.linenum = 1;
-    stepper.last = NULL;
+	program.max_instr = 0;
 
-    n_lookup = 0;
-    n_defs = 0;
+	stepper.linenum = 1;
+	stepper.last = NULL;
 
-    memset(program.bytes, 0, sizeof program);
+	n_lookup = 0;
+	n_defs = 0;
 
-    nextsym(&stepper);
-    while(stepper.sym != SYM_END) {
-        //c8_message("%d %d %s\n", stepper.linenum, stepper.sym, stepper->token);
-        switch(stepper.sym){
-        case SYM_DEFINE:
-        {
-            char name[TOK_SIZE];
-            nextsym(&stepper);
-            /* "Identifier expected" may also mean that the name has
-                already been used, eg. if aaa is already defined as 123
-                then define aaa 456 looks like define 123 456 */
-            if(stepper.sym != SYM_IDENTIFIER)
-                exit_error("error:%d: identifier expected, found %s\n", stepper.linenum, stepper.token);
-            strcpy(name,stepper.token);
-            nextsym(&stepper);
-            if(stepper.sym != SYM_NUMBER && stepper.sym != SYM_REGISTER)
-                exit_error("error:%d: value expected\n", stepper.linenum);
-            add_definition(&stepper, name);
-            nextsym(&stepper);
-        }
-        break;
-        case SYM_OFFSET:
-            nextsym(&stepper);
-            if(stepper.sym != SYM_NUMBER)
-                exit_error("error:%d: offset expected\n", stepper.linenum);
-            program.next_instr = get_addr(&stepper);
-            nextsym(&stepper);
-        break;
-        case SYM_DB:
-            do {
-                nextsym(&stepper);
-                if(stepper.sym == SYM_END)
-                    break;
-                if(stepper.sym != SYM_NUMBER)
-                    exit_error("error:%d: byte value expected\n", stepper.linenum);
-                emit_b(&stepper,get_byte(&stepper));
-                nextsym(&stepper);
-            } while(stepper.sym == ',');
-        break;
-        case SYM_DW:
-            do {
-                nextsym(&stepper);
-                if(stepper.sym == SYM_END)
-                    break;
-                if(stepper.sym != SYM_NUMBER)
-                    exit_error("error:%d: byte value expected\n", stepper.linenum);
-                uint16_t word = get_word(&stepper);
-                emit(&stepper, word);
-                nextsym(&stepper);
-            } while(stepper.sym == ',');
-        break;
-        case SYM_HI:
-            nextsym(&stepper);
-            if(stepper.sym != SYM_IDENTIFIER)
-                exit_error("error:%d: identifier expected, found %s\n", stepper.linenum, stepper.token);
-        break;
-        case SYM_LO:
-            nextsym(&stepper);
-            if(stepper.sym != SYM_IDENTIFIER)
-                exit_error("error:%d: identifier expected, found %s\n", stepper.linenum, stepper.token);
-        break;
-        case SYM_IDENTIFIER:
-            add_label(stepper.token, stepper.linenum);
-            expect(&stepper, ':');
-        break;
-        case SYM_INSTRUCTION:
-            if(!strcmp("cls", stepper.token))
-                emit(&stepper, 0x00E0);
-            else if(!strcmp("ret", stepper.token))
-                emit(&stepper, 0x00EE);
-            else if(!strcmp("jp", stepper.token)) {
-                nextsym(&stepper);
-                if(stepper.sym == SYM_IDENTIFIER)
-                    emit_l(&stepper, 0x1000);
-                else if(stepper.sym == SYM_REGISTER) {
-                    if(strcmp(stepper.token, "v0"))
-                        exit_error("error:%d: JP applies to V0 only\n", stepper.linenum);
-                    expect(&stepper, ',');
-                    if(stepper.sym == SYM_IDENTIFIER)
-                        emit_l(&stepper, 0xB000);
-                    else
-                        emit(&stepper, 0xB000 | get_addr(&stepper));
-                } else
-                    emit(&stepper, 0x1000 | get_addr(&stepper));
-            } else if(!strcmp("call", stepper.token)) {
-                nextsym(&stepper);
-                if(stepper.sym == SYM_IDENTIFIER)
-                    emit_l(&stepper, 0x2000);
-                else {
-                    if(stepper.sym != SYM_NUMBER)
-                        exit_error("error:%d: address expected", stepper.linenum);
-                    emit(&stepper, 0x2000 | get_addr(&stepper));
-                }
-            } else if(!strcmp("se", stepper.token)) {
-                nextsym(&stepper);
-                int regx = get_register(&stepper);
-                expect(&stepper, ',');
-                if(stepper.sym == SYM_NUMBER)
-                    emit(&stepper, 0x3000 | (regx << 8) | get_byte(&stepper));
-                else if(stepper.sym == SYM_REGISTER) {
-                    int regy = get_register(&stepper);
-                    emit(&stepper, 0x5000 | (regx << 8) | (regy << 4));
-                } else
-                    exit_error("error:%d: operand expected\n", stepper.linenum);
-            } else if(!strcmp("sne", stepper.token)) {
-                nextsym(&stepper);
-                int regx = get_register(&stepper);
-                expect(&stepper, ',');
-                if(stepper.sym == SYM_NUMBER) {
-                    emit(&stepper, 0x4000 | (regx << 8) | get_byte(&stepper));
-                } else if(stepper.sym == SYM_REGISTER) {
-                    int regy = get_register(&stepper);
-                    emit(&stepper, 0x9000 | (regx << 8) | (regy << 4));
-                } else
-                    exit_error("error:%d: operand expected\n", stepper.linenum);
-            } else if(!strcmp("add", stepper.token)) {
-                nextsym(&stepper);
-                if(stepper.sym == SYM_I) {
-                    expect(&stepper, ',');
-                    emit(&stepper, 0xF01E | (get_register(&stepper) << 8));
-                } else {
-                    int regx = get_register(&stepper);
-                    expect(&stepper, ',');
-                    if(stepper.sym == SYM_NUMBER) {
-                        emit(&stepper, 0x7000 | (regx << 8) | get_byte(&stepper));
-                    } else if(stepper.sym == SYM_REGISTER) {
-                        int regy = get_register(&stepper);
-                        emit(&stepper, 0x8004 | (regx << 8) | (regy << 4));
-                    } else
-                        exit_error("error:%d: operand expected\n", stepper.linenum);
-                }
-            } else if(!strcmp("ld", stepper.token)) {
-                nextsym(&stepper);
-                if(stepper.sym == SYM_I) {
-                    expect(&stepper, ',');
-                    if(stepper.sym == SYM_IDENTIFIER)
-                        emit_l(&stepper, 0xA000);
-                    else
-                        emit(&stepper, 0xA000 | get_addr(&stepper));
-                } else if(stepper.sym == SYM_DT) {
-                    expect(&stepper, ',');
-                    emit(&stepper, 0xF015 | (get_register(&stepper) << 8));
-                } else if(stepper.sym == SYM_ST) {
-                    expect(&stepper, ',');
-                    emit(&stepper, 0xF018 | (get_register(&stepper) << 8));
-                } else if(stepper.sym == SYM_F) {
-                    expect(&stepper, ',');
-                    emit(&stepper, 0xF029 | (get_register(&stepper) << 8));
-                } else if(stepper.sym == SYM_B) {
-                    expect(&stepper, ',');
-                    emit(&stepper, 0xF033 | (get_register(&stepper) << 8));
-                } else if(stepper.sym == '[') {
-                    if(nextsym(&stepper) != SYM_I || nextsym(&stepper) != ']')
-                        exit_error("error:%d: [I] expected\n", stepper.linenum);
-                    if(nextsym(&stepper) != ',')
-                        exit_error("error:%d: ',' expected\n", stepper.linenum);
-                    nextsym(&stepper);
-                    emit(&stepper, 0xF055 | (get_register(&stepper) << 8));
-                } else if(stepper.sym == SYM_HF) {
-                    expect(&stepper, ',');
-                    emit(&stepper, 0xF030 | (get_register(&stepper) << 8));
-                } else if(stepper.sym == SYM_R) {
-                    expect(&stepper, ',');
-                    emit(&stepper, 0xF075 | (get_register(&stepper) << 8));
-                } else {
-                    int regx = get_register(&stepper);
-                    expect(&stepper, ',');
-                    if(stepper.sym == SYM_NUMBER)
-                        emit(&stepper, 0x6000 | (regx << 8) | get_byte(&stepper));
-                    else if(stepper.sym == SYM_REGISTER) {
-                        int regy = get_register(&stepper);
-                        emit(&stepper, 0x8000 | (regx << 8) | (regy << 4));
-                    } else if(stepper.sym == SYM_DT)
-                        emit(&stepper, 0xF007 | (regx << 8));
-                    else if(stepper.sym == SYM_K)
-                        emit(&stepper, 0xF00A | (regx << 8));
-                    else if(stepper.sym == '[') {
-                        if(nextsym(&stepper) != SYM_I || nextsym(&stepper) != ']')
-                            exit_error("error:%d: [I] expected\n", stepper.linenum);
-                        emit(&stepper, 0xF065 | (regx << 8));
-                    } else if(stepper.sym == SYM_R) {
-                        emit(&stepper, 0xF085 | (regx << 8));
-                    } else
-                        exit_error("error:%d: operand expected\n", stepper.linenum);
-                }
-            } else if(!strcmp("or", stepper.token)) {
-                nextsym(&stepper);
-                int regx = get_register(&stepper);
-                expect(&stepper, ',');
-                int regy = get_register(&stepper);
-                emit(&stepper, 0x8001 | (regx << 8) | (regy << 4));
-            } else if(!strcmp("and", stepper.token)) {
-                nextsym(&stepper);
-                int regx = get_register(&stepper);
-                expect(&stepper, ',');
-                int regy = get_register(&stepper);
-                emit(&stepper, 0x8002 | (regx << 8) | (regy << 4));
-            } else if(!strcmp("xor", stepper.token)) {
-                nextsym(&stepper);
-                int regx = get_register(&stepper);
-                expect(&stepper, ',');
-                int regy = get_register(&stepper);
-                emit(&stepper, 0x8003 | (regx << 8) | (regy << 4));
-            } else if(!strcmp("sub", stepper.token)) {
-                nextsym(&stepper);
-                int regx = get_register(&stepper);
-                expect(&stepper, ',');
-                int regy = get_register(&stepper);
-                emit(&stepper, 0x8005 | (regx << 8) | (regy << 4));
-            } else if(!strcmp("shr", stepper.token)) {
-                nextsym(&stepper);
-                int regx = get_register(&stepper);
-                int regy = 0;
-                nextsym(&stepper);
-                if(stepper.sym == ',') {
-                    nextsym(&stepper);
-                    regy = get_register(&stepper);
-                } else
-                    stepper.in=stepper.last;
-                emit(&stepper, 0x8006 | (regx << 8) | (regy << 4));
-            } else if(!strcmp("subn", stepper.token)) {
-                nextsym(&stepper);
-                int regx = get_register(&stepper);
-                expect(&stepper, ',');
-                int regy = get_register(&stepper);
-                emit(&stepper, 0x8007 | (regx << 8) | (regy << 4));
-            } else if(!strcmp("shl", stepper.token)) {
-                nextsym(&stepper);
-                int regx = get_register(&stepper);
-                int regy=0;
-                nextsym(&stepper);
-                if(stepper.sym == ',') {
-                    nextsym(&stepper);
-                    regy = get_register(&stepper);
-                } else
-                    stepper.in=stepper.last;
-                emit(&stepper, 0x800E | (regx << 8) | (regy << 4));
-            } else if(!strcmp("rnd", stepper.token)) {
-                nextsym(&stepper);
-                int regx = get_register(&stepper);
-                expect(&stepper, ',');
-                if(stepper.sym != SYM_NUMBER)
-                    exit_error("error:%d: operand expected\n", stepper.linenum);
-                emit(&stepper, 0xC000 | (regx << 8) | get_byte(&stepper));
-            }  else if(!strcmp("drw", stepper.token)) {
-                nextsym(&stepper);
-                int regx = get_register(&stepper);
-                expect(&stepper, ',');
-                int regy = get_register(&stepper);
-                expect(&stepper, ',');
-                int nib = get_byte(&stepper);
-                if(nib < 0 || nib > 0xF)
-                    exit_error("error:%d: invalid value %d\n", stepper.linenum, nib);
-                emit(&stepper, 0xD000 | (regx << 8) | (regy << 4) | nib);
-            } else if(!strcmp("skp", stepper.token)) {
-                nextsym(&stepper);
-                emit(&stepper, 0xE09E | (get_register(&stepper) << 8));
-            } else if(!strcmp("sknp", stepper.token)) {
-                nextsym(&stepper);
-                emit(&stepper, 0xE0A1 | (get_register(&stepper) << 8));
-            } else if(!strcmp("scd", stepper.token)) {
-                nextsym(&stepper);
-                int nib = get_byte(&stepper);
-                if(nib < 0 || nib > 0xF)
-                    exit_error("error:%d: invalid value %d\n", stepper.linenum, nib);
-                emit(&stepper, 0x00C0 | nib);
-            } else if(!strcmp("scr", stepper.token)) {
-                emit(&stepper, 0x00FB);
-            } else if(!strcmp("scl", stepper.token)) {
-                emit(&stepper, 0x00FC);
-            } else if(!strcmp("exit", stepper.token)) {
-                emit(&stepper, 0x00FD);
-            } else if(!strcmp("low", stepper.token)) {
-                emit(&stepper, 0x00FE);
-            } else if(!strcmp("high", stepper.token)) {
-                emit(&stepper, 0x00FF);
-            } else if(!strcmp("sys", stepper.token)) {
-#if 1
-                /* SYS is not supported in modern emulators */
-                exit_error("error:%d: SYS support is disabled\n", stepper.linenum);
-#else
-                nextsym(&stepper);
-                emit(0x0000 | get_addr(&stepper));
-#endif
-            }
+	memset(program.bytes, 0, sizeof program);
+	program.next_instr = 512;
 
-            nextsym(&stepper);
-        break;
-        default:
-            exit_error("error:%d: unexpected token [%d]: '%s'\n", stepper.linenum, stepper.sym, stepper.token);
-        }
-    }
+	nextsym(&stepper);
+	while(stepper.sym != SYM_END) {
+		switch(stepper.sym){
+		case SYM_DEFINE:
+		{
+			char name[TOK_SIZE];
+			nextsym(&stepper);
+			/* "Identifier expected" may also mean that the name has
+				already been used, eg. if aaa is already defined as 123
+				then define aaa 456 looks like define 123 456 */
+			if(stepper.sym != SYM_IDENTIFIER)
+				exit_error("error:%d: identifier expected, found %s\n", stepper.linenum, stepper.token);
+			strcpy(name,stepper.token);
+			nextsym(&stepper);
+			if(stepper.sym != SYM_NUMBER && stepper.sym != SYM_REGISTER)
+				exit_error("error:%d: value expected\n", stepper.linenum);
+			add_definition(&stepper, name);
+			nextsym(&stepper);
+		}
+		break;
+		case SYM_OFFSET:
+			nextsym(&stepper);
+			if(stepper.sym != SYM_NUMBER)
+				exit_error("error:%d: offset expected\n", stepper.linenum);
+			program.next_instr = get_addr(&stepper);
+			nextsym(&stepper);
+		break;
+		case SYM_DB:
+			do {
+				nextsym(&stepper);
+				if(stepper.sym == SYM_END)
+					break;
+				if(stepper.sym != SYM_NUMBER)
+					exit_error("error:%d: byte value expected\n", stepper.linenum);
+				emit_b(&stepper,get_byte(&stepper));
+				nextsym(&stepper);
+			} while(stepper.sym == ',');
+		break;
+		case SYM_DW:
+			do {
+				nextsym(&stepper);
+				if(stepper.sym == SYM_END)
+					break;
+				if(stepper.sym != SYM_NUMBER)
+					exit_error("error:%d: byte value expected\n", stepper.linenum);
+				uint16_t word = get_word(&stepper);
+				emit(&stepper, word);
+				nextsym(&stepper);
+			} while(stepper.sym == ',');
+		break;
+		case SYM_IDENTIFIER:
+			add_label(stepper.token, stepper.linenum);
+			expect(&stepper, ':');
+		break;
+		case SYM_INSTRUCTION:
+			if(!strcmp("cls", stepper.token))
+				emit(&stepper, 0x00E0);
+			else if(!strcmp("ret", stepper.token))
+				emit(&stepper, 0x00EE);
+			else if(!strcmp("jp", stepper.token)) {
+				nextsym(&stepper);
+				if(stepper.sym == SYM_IDENTIFIER)
+					emit_l(&stepper, 0x1000, LT_FULL);
+				else if(stepper.sym == SYM_REGISTER) {
+					if(strcmp(stepper.token, "v0"))
+						exit_error("error:%d: JP applies to V0 only\n", stepper.linenum);
+					expect(&stepper, ',');
+					if(stepper.sym == SYM_IDENTIFIER)
+						emit_l(&stepper, 0xB000, LT_FULL);
+					else
+						emit(&stepper, 0xB000 | get_addr(&stepper));
+				} else
+					emit(&stepper, 0x1000 | get_addr(&stepper));
+			} else if(!strcmp("call", stepper.token)) {
+				nextsym(&stepper);
+				if(stepper.sym == SYM_IDENTIFIER)
+					emit_l(&stepper, 0x2000, LT_FULL);
+				else {
+					if(stepper.sym != SYM_NUMBER)
+						exit_error("error:%d: address expected", stepper.linenum);
+					emit(&stepper, 0x2000 | get_addr(&stepper));
+				}
+			} else if(!strcmp("se", stepper.token)) {
+				nextsym(&stepper);
+				int regx = get_register(&stepper);
+				expect(&stepper, ',');
+				if(stepper.sym == SYM_NUMBER)
+					emit(&stepper, 0x3000 | (regx << 8) | get_byte(&stepper));
+				else if(stepper.sym == SYM_REGISTER) {
+					int regy = get_register(&stepper);
+					emit(&stepper, 0x5000 | (regx << 8) | (regy << 4));
+				} else
+					exit_error("error:%d: operand expected\n", stepper.linenum);
+			} else if(!strcmp("sne", stepper.token)) {
+				nextsym(&stepper);
+				int regx = get_register(&stepper);
+				expect(&stepper, ',');
+				if(stepper.sym == SYM_NUMBER) {
+					emit(&stepper, 0x4000 | (regx << 8) | get_byte(&stepper));
+				} else if(stepper.sym == SYM_REGISTER) {
+					int regy = get_register(&stepper);
+					emit(&stepper, 0x9000 | (regx << 8) | (regy << 4));
+				} else
+					exit_error("error:%d: operand expected\n", stepper.linenum);
+			} else if(!strcmp("add", stepper.token)) {
+				nextsym(&stepper);
+				if(stepper.sym == SYM_I) {
+					expect(&stepper, ',');
+					emit(&stepper, 0xF01E | (get_register(&stepper) << 8));
+				} else {
+					int regx = get_register(&stepper);
+					expect(&stepper, ',');
+					if(stepper.sym == SYM_NUMBER) {
+						emit(&stepper, 0x7000 | (regx << 8) | get_byte(&stepper));
+					} else if(stepper.sym == SYM_REGISTER) {
+						int regy = get_register(&stepper);
+						emit(&stepper, 0x8004 | (regx << 8) | (regy << 4));
+					} else
+						exit_error("error:%d: operand expected\n", stepper.linenum);
+				}
+			} else if(!strcmp("ld", stepper.token)) {
+				nextsym(&stepper);
+				if(stepper.sym == SYM_I) {
+					expect(&stepper, ',');
+					if(stepper.sym == SYM_IDENTIFIER)
+						emit_l(&stepper, 0xA000, LT_FULL);
+					else
+						emit(&stepper, 0xA000 | get_addr(&stepper));
+				} else if(stepper.sym == SYM_DT) {
+					expect(&stepper, ',');
+					emit(&stepper, 0xF015 | (get_register(&stepper) << 8));
+				} else if(stepper.sym == SYM_ST) {
+					expect(&stepper, ',');
+					emit(&stepper, 0xF018 | (get_register(&stepper) << 8));
+				} else if(stepper.sym == SYM_F) {
+					expect(&stepper, ',');
+					emit(&stepper, 0xF029 | (get_register(&stepper) << 8));
+				} else if(stepper.sym == SYM_B) {
+					expect(&stepper, ',');
+					emit(&stepper, 0xF033 | (get_register(&stepper) << 8));
+				} else if(stepper.sym == '[') {
+					if(nextsym(&stepper) != SYM_I || nextsym(&stepper) != ']')
+						exit_error("error:%d: [I] expected\n", stepper.linenum);
+					if(nextsym(&stepper) != ',')
+						exit_error("error:%d: ',' expected\n", stepper.linenum);
+					nextsym(&stepper);
+					emit(&stepper, 0xF055 | (get_register(&stepper) << 8));
+				} else if(stepper.sym == SYM_HF) {
+					expect(&stepper, ',');
+					emit(&stepper, 0xF030 | (get_register(&stepper) << 8));
+				} else if(stepper.sym == SYM_R) {
+					expect(&stepper, ',');
+					emit(&stepper, 0xF075 | (get_register(&stepper) << 8));
+				} else {
+					int regx = get_register(&stepper);
+					expect(&stepper, ',');
+					if(stepper.sym == SYM_NUMBER)
+						emit(&stepper, 0x6000 | (regx << 8) | get_byte(&stepper));
+					else if(stepper.sym == SYM_REGISTER) {
+						int regy = get_register(&stepper);
+						emit(&stepper, 0x8000 | (regx << 8) | (regy << 4));
+					} else if(stepper.sym == SYM_DT)
+						emit(&stepper, 0xF007 | (regx << 8));
+					else if(stepper.sym == SYM_K)
+						emit(&stepper, 0xF00A | (regx << 8));
+					else if (stepper.sym == SYM_HI){
+						nextsym(&stepper);
+						if (stepper.sym!=SYM_IDENTIFIER)
+							exit_error("error:%d: identifier expected, found %s\n", stepper.linenum, stepper.token);
+						emit_l(&stepper, 0x6000 | (regx << 8),LT_HI);
+					}
+					else if (stepper.sym == SYM_LO){
+						nextsym(&stepper);
+						if (stepper.sym!=SYM_IDENTIFIER)
+							exit_error("error:%d: identifier expected, found %s\n", stepper.linenum, stepper.token);
+						emit_l(&stepper, 0x6000 | (regx << 8),LT_LO);
+					}
+					else if(stepper.sym == '[') {
+						if(nextsym(&stepper) != SYM_I || nextsym(&stepper) != ']')
+							exit_error("error:%d: [I] expected\n", stepper.linenum);
+						emit(&stepper, 0xF065 | (regx << 8));
+					} else if(stepper.sym == SYM_R) {
+						emit(&stepper, 0xF085 | (regx << 8));
+					} else
+						exit_error("error:%d: operand expected, found %s[%d]\n", stepper.linenum, stepper.token, stepper.sym);
+				}
+			} else if(!strcmp("or", stepper.token)) {
+				nextsym(&stepper);
+				int regx = get_register(&stepper);
+				expect(&stepper, ',');
+				int regy = get_register(&stepper);
+				emit(&stepper, 0x8001 | (regx << 8) | (regy << 4));
+			} else if(!strcmp("and", stepper.token)) {
+				nextsym(&stepper);
+				int regx = get_register(&stepper);
+				expect(&stepper, ',');
+				int regy = get_register(&stepper);
+				emit(&stepper, 0x8002 | (regx << 8) | (regy << 4));
+			} else if(!strcmp("xor", stepper.token)) {
+				nextsym(&stepper);
+				int regx = get_register(&stepper);
+				expect(&stepper, ',');
+				int regy = get_register(&stepper);
+				emit(&stepper, 0x8003 | (regx << 8) | (regy << 4));
+			} else if(!strcmp("sub", stepper.token)) {
+				nextsym(&stepper);
+				int regx = get_register(&stepper);
+				expect(&stepper, ',');
+				int regy = get_register(&stepper);
+				emit(&stepper, 0x8005 | (regx << 8) | (regy << 4));
+			} else if(!strcmp("shr", stepper.token)) {
+				nextsym(&stepper);
+				int regx = get_register(&stepper);
+				int regy = 0;
+				nextsym(&stepper);
+				if(stepper.sym == ',') {
+					nextsym(&stepper);
+					regy = get_register(&stepper);
+				} else
+					stepper.in=stepper.last;
+				emit(&stepper, 0x8006 | (regx << 8) | (regy << 4));
+			} else if(!strcmp("subn", stepper.token)) {
+				nextsym(&stepper);
+				int regx = get_register(&stepper);
+				expect(&stepper, ',');
+				int regy = get_register(&stepper);
+				emit(&stepper, 0x8007 | (regx << 8) | (regy << 4));
+			} else if(!strcmp("shl", stepper.token)) {
+				nextsym(&stepper);
+				int regx = get_register(&stepper);
+				int regy=0;
+				nextsym(&stepper);
+				if(stepper.sym == ',') {
+					nextsym(&stepper);
+					regy = get_register(&stepper);
+				} else
+					stepper.in=stepper.last;
+				emit(&stepper, 0x800E | (regx << 8) | (regy << 4));
+			} else if(!strcmp("rnd", stepper.token)) {
+				nextsym(&stepper);
+				int regx = get_register(&stepper);
+				expect(&stepper, ',');
+				if(stepper.sym != SYM_NUMBER)
+					exit_error("error:%d: operand expected\n", stepper.linenum);
+				emit(&stepper, 0xC000 | (regx << 8) | get_byte(&stepper));
+			}  else if(!strcmp("drw", stepper.token)) {
+				nextsym(&stepper);
+				int regx = get_register(&stepper);
+				expect(&stepper, ',');
+				int regy = get_register(&stepper);
+				expect(&stepper, ',');
+				int nib = get_byte(&stepper);
+				if(nib < 0 || nib > 0xF)
+					exit_error("error:%d: invalid value %d\n", stepper.linenum, nib);
+				emit(&stepper, 0xD000 | (regx << 8) | (regy << 4) | nib);
+			} else if(!strcmp("skp", stepper.token)) {
+				nextsym(&stepper);
+				emit(&stepper, 0xE09E | (get_register(&stepper) << 8));
+			} else if(!strcmp("sknp", stepper.token)) {
+				nextsym(&stepper);
+				emit(&stepper, 0xE0A1 | (get_register(&stepper) << 8));
+			} else if(!strcmp("scd", stepper.token)) {
+				nextsym(&stepper);
+				int nib = get_byte(&stepper);
+				if(nib < 0 || nib > 0xF)
+					exit_error("error:%d: invalid value %d\n", stepper.linenum, nib);
+				emit(&stepper, 0x00C0 | nib);
+			} else if(!strcmp("scr", stepper.token)) {
+				emit(&stepper, 0x00FB);
+			} else if(!strcmp("scl", stepper.token)) {
+				emit(&stepper, 0x00FC);
+			} else if(!strcmp("exit", stepper.token)) {
+				emit(&stepper, 0x00FD);
+			} else if(!strcmp("low", stepper.token)) {
+				emit(&stepper, 0x00FE);
+			} else if(!strcmp("high", stepper.token)) {
+				emit(&stepper, 0x00FF);
+			} else if(!strcmp("sys", stepper.token)) {
+				nextsym(&stepper);
+				emit(&stepper, 0x0000 | get_addr(&stepper));
+			}
 
-    if(c8_verbose) c8_message("Resolving labels...\n");
-    size_t n = PROG_OFFSET;
-    bool success=false;
-    for(int i = PROG_OFFSET; i < program.max_instr; i++) {
-        if(*program.bytes[i].label) {
-            for(int j = 0; j < n_lookup; j++) {
-                if(!strcmp(lookup[j].label, program.bytes[i].label)) {
-                    assert(lookup[j].addr <= 0xFFF);
-                    program.bytes[i].byte |= (lookup[j].addr >> 8);
-                    program.bytes[i + 1].byte = lookup[j].addr & 0xFF;
-                    //free(program[i].label);
-                    //program.bytes[i].label = NULL;
-                    success=true;
-                    break;
-                }
-            }
-            if(!success)
-                exit_error("error:%d: unresolved label '%s'\n", program.bytes[i].linenum, program.bytes[i].label);
-        }
-        if(c8_verbose > 1) {
-            if(!(i & 0x01))
-                c8_message("%03X: %02X", i, program.bytes[i].byte);
-            else
-                c8_message("%02X\n", program.bytes[i].byte);
-        }
+			nextsym(&stepper);
+		break;
+		default:
+			exit_error("error:%d: unexpected token [%d]: '%s'\n", stepper.linenum, stepper.sym, stepper.token);
+		}
+	}
 
-        c8_set(n++, program.bytes[i].byte);
-    }
-    if(c8_verbose > 1 && success)
-        c8_message("\n");
+	if(c8_verbose) c8_message("Resolving labels...\n");
+	size_t n = PROG_OFFSET;
+	bool success=false;
+	for(int i = PROG_OFFSET; i < program.max_instr; i++) {
+		if(program.bytes[i].tlabel) {
+			for(int j = 0; j < n_lookup; j++) {
+				if(!strcmp(lookup[j].label, program.bytes[i].label)) {
+					assert(lookup[j].addr <= 0xFFF);
+					switch (program.bytes[i].tlabel)
+					{
+						case LT_FULL:
+						program.bytes[i].byte |= (lookup[j].addr >> 8);
+						program.bytes[i + 1].byte = lookup[j].addr & 0xFF;
+						break;   
+						case LT_HI:
+						program.bytes[i].byte = (lookup[j].addr >> 8);
+						break;
+						case LT_LO:
+						program.bytes[i].byte = lookup[j].addr & 0xFF;
+						break;
 
-    if(c8_verbose) c8_message("Assembled; %d bytes.\n", program.max_instr - PROG_OFFSET);
-    /*
-    for(i = 0; i < n_lookup; i++) {
-        free(lookup[i].label);
-    }
-    for(i = 0; i < n_defs; i++) {
-        free(defs[i].name);
-        free(defs[i].value);
-    }
-    */
-    return 0;
+					}
+					success=true;
+					break;
+				}
+			}
+			if(!success)
+				exit_error("error:%d: unresolved label '%s'\n", program.bytes[i].linenum, program.bytes[i].label);
+		}
+		if(c8_verbose > 1) {
+			if(!(i & 0x01))
+				c8_message("%03X: %02X", i, program.bytes[i].byte);
+			else
+				c8_message("%02X\n", program.bytes[i].byte);
+		}
+
+		c8_set(n++, program.bytes[i].byte);
+	}
+	if(c8_verbose > 1 && success)
+		c8_message("\n");
+
+	if(c8_verbose) c8_message("Assembled; %d bytes.\n", program.max_instr - PROG_OFFSET);
+
+	return 0;
 }

--- a/c8asm.c
+++ b/c8asm.c
@@ -224,43 +224,7 @@ static int parse_int(const char ** expression,const int linenum){
 		(*expression)++;
 	return (int)strtol(*expression, expression, base);	
 }
-/*
-static void copy_arithmetic_expression(char * buffer, const char ** in){
-	while(1){
-		if (**in == ' '){
-			(*in)++;
-			continue;
-		} else if (get_base(*in)>0){
-			const char * new=*in;
-			parse_int(&new, 0);
-			memcpy(buffer, *in, new-(*in));
-			buffer+=new-(*in);
-			*in=new;
-		} else if (
-			is_unary_operator(*in) || get_precedence(*in) || 
-			**in == '(' || **in == ')'
-			){
-				*(buffer++)=*((*in)++);
-				if (**in == '<' || **in == '>') *(buffer++)=*((*in)++);
 
-		} else {
-			bool success = false;
-			for(int i = 0; i < n_lookup; i++) {
-				if(!strcmp(lookup[i].label, *in)) {
-					size_t bytes_to_copy = strlen(lookup[i].label);
-					memcpy(buffer, *in,bytes_to_copy);
-					buffer+=bytes_to_copy;
-					*in+=bytes_to_copy;
-					success = true;
-					break;
-				}
-			}
-			if(!success) break;
-		}
-	}
-	*buffer='\0';
-}
-*/
 
 
 static void copy_arithmetic_expression(char * buffer, const char ** in){
@@ -440,44 +404,7 @@ static int evaluate_arithmetic_expression(const char * expression, const int lin
 	return *figures.stack;
 
 }
-/*
-static void emit_b(const Stepper * stepper, uint8_t byte) {
-	if(program.next_instr >= TOTAL_RAM)
-		exit_error("error: program too large\n");
-	program.bytes[program.next_instr].linenum = stepper->linenum;
-	program.bytes[program.next_instr++].byte = byte;
-	if(program.next_instr > program.max_instr)
-		program.max_instr = program.next_instr;
-}
 
-static inline void emit(const Stepper * stepper, uint16_t inst) {
-	emit_b(stepper, inst >> 8);
-	emit_b(stepper, inst & 0xFF);
-}
-static void emit_lb(const Stepper * stepper, LABEL_TYPE tlabel){
-	if(program.next_instr >= TOTAL_RAM)
-		exit_error("error: program too large\n");
-	program.bytes[program.next_instr].linenum = stepper->linenum;
-	strcpy(program.bytes[program.next_instr].label, stepper->token);
-	program.bytes[program.next_instr].tlabel=tlabel;
-	program.bytes[program.next_instr++].byte = 0;
-	if(program.next_instr > program.max_instr)
-		program.max_instr = program.next_instr;
-}
-static void emit_l(const Stepper * stepper, uint16_t inst, LABEL_TYPE tlabel){
-	if (tlabel == LT_NONE){
-		exit_error("emit_l called on NONE label\n");
-	} else if (tlabel == LT_FULL){
-		strcpy(program.bytes[program.next_instr].label, stepper->token);
-		program.bytes[program.next_instr].tlabel=LT_FULL;
-		emit(stepper, inst & 0xf000);
-	} else {
-		emit_b(stepper, inst>>8);
-		emit_lb(stepper, tlabel);
-	}
-}
-
-*/
 static void emit_b(const Stepper * stepper, uint8_t byte, const EMITTED_TYPE type) {
 	if(program.next_instr >= TOTAL_RAM)
 		exit_error("error: program too large\n");

--- a/c8asm.c
+++ b/c8asm.c
@@ -156,10 +156,9 @@ static inline void emit_l(const Stepper * stepper, uint16_t inst){
 
 
 static void add_label(const char *label, const int linenum) {
-    int i;
     if(n_lookup == MAX_LOOKUP)
         exit_error("error: too many entries in lookup\n");
-    for(i = 0; i < n_lookup; i++)
+    for(int i = 0; i < n_lookup; i++)
         if(!strcmp(lookup[i].label, label))
             exit_error("error:%d: duplicate label '%s'\n", linenum, label);
     strcpy(lookup[n_lookup].label, label);
@@ -202,11 +201,10 @@ scan_start:
     
 
     if(isalpha(*stepper->in)) {
-        int i;
         while(isalnum(*stepper->in) || *stepper->in == '_')
             *tok++ = tolower(*stepper->in++);
         *tok = '\0';
-        for(i = 0; i < (sizeof inst_names)/(sizeof inst_names[0]); i++)
+        for(int i = 0; i < (sizeof inst_names)/(sizeof inst_names[0]); i++)
             if(!strcmp(inst_names[i], stepper->token)) {
                 stepper->sym = SYM_INSTRUCTION;
                 break;
@@ -246,7 +244,7 @@ scan_start:
 
             else {
                 stepper->sym = SYM_IDENTIFIER;
-                for(i = 0; i < n_defs; i++) {
+                for(int i = 0; i < n_defs; i++) {
                     if(!strcmp(defs[i].name, stepper->token)) {
                         stepper->sym = defs[i].type;
                         strcpy(stepper->token, defs[i].value);
@@ -342,7 +340,6 @@ static int get_word(const Stepper * stepper) {
 int c8_assemble(const char *text) {
 
     static Stepper stepper;
-    int i, j, regx = -1, regy = 0;
     stepper.in = text;
 
     if(c8_verbose) c8_message("Assembling...\n");
@@ -363,8 +360,9 @@ int c8_assemble(const char *text) {
         //c8_message("%d %d %s\n", stepper.linenum, stepper.sym, stepper->token);
         switch(stepper.sym){
         case SYM_DEFINE:
-            nextsym(&stepper);
+        {
             char name[TOK_SIZE];
+            nextsym(&stepper);
             /* "Identifier expected" may also mean that the name has
                 already been used, eg. if aaa is already defined as 123
                 then define aaa 456 looks like define 123 456 */
@@ -376,6 +374,7 @@ int c8_assemble(const char *text) {
                 exit_error("error:%d: value expected\n", stepper.linenum);
             add_definition(&stepper, name);
             nextsym(&stepper);
+        }
         break;
         case SYM_OFFSET:
             nextsym(&stepper);
@@ -451,23 +450,23 @@ int c8_assemble(const char *text) {
                 }
             } else if(!strcmp("se", stepper.token)) {
                 nextsym(&stepper);
-                regx = get_register(&stepper);
+                int regx = get_register(&stepper);
                 expect(&stepper, ',');
                 if(stepper.sym == SYM_NUMBER)
                     emit(&stepper, 0x3000 | (regx << 8) | get_byte(&stepper));
                 else if(stepper.sym == SYM_REGISTER) {
-                    regy = get_register(&stepper);
+                    int regy = get_register(&stepper);
                     emit(&stepper, 0x5000 | (regx << 8) | (regy << 4));
                 } else
                     exit_error("error:%d: operand expected\n", stepper.linenum);
             } else if(!strcmp("sne", stepper.token)) {
                 nextsym(&stepper);
-                regx = get_register(&stepper);
+                int regx = get_register(&stepper);
                 expect(&stepper, ',');
                 if(stepper.sym == SYM_NUMBER) {
                     emit(&stepper, 0x4000 | (regx << 8) | get_byte(&stepper));
                 } else if(stepper.sym == SYM_REGISTER) {
-                    regy = get_register(&stepper);
+                    int regy = get_register(&stepper);
                     emit(&stepper, 0x9000 | (regx << 8) | (regy << 4));
                 } else
                     exit_error("error:%d: operand expected\n", stepper.linenum);
@@ -477,12 +476,12 @@ int c8_assemble(const char *text) {
                     expect(&stepper, ',');
                     emit(&stepper, 0xF01E | (get_register(&stepper) << 8));
                 } else {
-                    regx = get_register(&stepper);
+                    int regx = get_register(&stepper);
                     expect(&stepper, ',');
                     if(stepper.sym == SYM_NUMBER) {
                         emit(&stepper, 0x7000 | (regx << 8) | get_byte(&stepper));
                     } else if(stepper.sym == SYM_REGISTER) {
-                        regy = get_register(&stepper);
+                        int regy = get_register(&stepper);
                         emit(&stepper, 0x8004 | (regx << 8) | (regy << 4));
                     } else
                         exit_error("error:%d: operand expected\n", stepper.linenum);
@@ -521,12 +520,12 @@ int c8_assemble(const char *text) {
                     expect(&stepper, ',');
                     emit(&stepper, 0xF075 | (get_register(&stepper) << 8));
                 } else {
-                    regx = get_register(&stepper);
+                    int regx = get_register(&stepper);
                     expect(&stepper, ',');
                     if(stepper.sym == SYM_NUMBER)
                         emit(&stepper, 0x6000 | (regx << 8) | get_byte(&stepper));
                     else if(stepper.sym == SYM_REGISTER) {
-                        regy = get_register(&stepper);
+                        int regy = get_register(&stepper);
                         emit(&stepper, 0x8000 | (regx << 8) | (regy << 4));
                     } else if(stepper.sym == SYM_DT)
                         emit(&stepper, 0xF007 | (regx << 8));
@@ -543,31 +542,32 @@ int c8_assemble(const char *text) {
                 }
             } else if(!strcmp("or", stepper.token)) {
                 nextsym(&stepper);
-                regx = get_register(&stepper);
+                int regx = get_register(&stepper);
                 expect(&stepper, ',');
-                regy = get_register(&stepper);
+                int regy = get_register(&stepper);
                 emit(&stepper, 0x8001 | (regx << 8) | (regy << 4));
             } else if(!strcmp("and", stepper.token)) {
                 nextsym(&stepper);
-                regx = get_register(&stepper);
+                int regx = get_register(&stepper);
                 expect(&stepper, ',');
-                regy = get_register(&stepper);
+                int regy = get_register(&stepper);
                 emit(&stepper, 0x8002 | (regx << 8) | (regy << 4));
             } else if(!strcmp("xor", stepper.token)) {
                 nextsym(&stepper);
-                regx = get_register(&stepper);
+                int regx = get_register(&stepper);
                 expect(&stepper, ',');
-                regy = get_register(&stepper);
+                int regy = get_register(&stepper);
                 emit(&stepper, 0x8003 | (regx << 8) | (regy << 4));
             } else if(!strcmp("sub", stepper.token)) {
                 nextsym(&stepper);
-                regx = get_register(&stepper);
+                int regx = get_register(&stepper);
                 expect(&stepper, ',');
-                regy = get_register(&stepper);
+                int regy = get_register(&stepper);
                 emit(&stepper, 0x8005 | (regx << 8) | (regy << 4));
             } else if(!strcmp("shr", stepper.token)) {
                 nextsym(&stepper);
-                regx = get_register(&stepper);
+                int regx = get_register(&stepper);
+                int regy = 0;
                 nextsym(&stepper);
                 if(stepper.sym == ',') {
                     nextsym(&stepper);
@@ -577,13 +577,14 @@ int c8_assemble(const char *text) {
                 emit(&stepper, 0x8006 | (regx << 8) | (regy << 4));
             } else if(!strcmp("subn", stepper.token)) {
                 nextsym(&stepper);
-                regx = get_register(&stepper);
+                int regx = get_register(&stepper);
                 expect(&stepper, ',');
-                regy = get_register(&stepper);
+                int regy = get_register(&stepper);
                 emit(&stepper, 0x8007 | (regx << 8) | (regy << 4));
             } else if(!strcmp("shl", stepper.token)) {
                 nextsym(&stepper);
-                regx = get_register(&stepper);
+                int regx = get_register(&stepper);
+                int regy=0;
                 nextsym(&stepper);
                 if(stepper.sym == ',') {
                     nextsym(&stepper);
@@ -593,16 +594,16 @@ int c8_assemble(const char *text) {
                 emit(&stepper, 0x800E | (regx << 8) | (regy << 4));
             } else if(!strcmp("rnd", stepper.token)) {
                 nextsym(&stepper);
-                regx = get_register(&stepper);
+                int regx = get_register(&stepper);
                 expect(&stepper, ',');
                 if(stepper.sym != SYM_NUMBER)
                     exit_error("error:%d: operand expected\n", stepper.linenum);
                 emit(&stepper, 0xC000 | (regx << 8) | get_byte(&stepper));
             }  else if(!strcmp("drw", stepper.token)) {
                 nextsym(&stepper);
-                regx = get_register(&stepper);
+                int regx = get_register(&stepper);
                 expect(&stepper, ',');
-                regy = get_register(&stepper);
+                int regy = get_register(&stepper);
                 expect(&stepper, ',');
                 int nib = get_byte(&stepper);
                 if(nib < 0 || nib > 0xF)
@@ -649,10 +650,10 @@ int c8_assemble(const char *text) {
 
     if(c8_verbose) c8_message("Resolving labels...\n");
     size_t n = PROG_OFFSET;
-    for(i = PROG_OFFSET; i < program.max_instr; i++) {
+    bool success=false;
+    for(int i = PROG_OFFSET; i < program.max_instr; i++) {
         if(*program.bytes[i].label) {
-            bool success=false;
-            for(j = 0; j < n_lookup; j++) {
+            for(int j = 0; j < n_lookup; j++) {
                 if(!strcmp(lookup[j].label, program.bytes[i].label)) {
                     assert(lookup[j].addr <= 0xFFF);
                     program.bytes[i].byte |= (lookup[j].addr >> 8);
@@ -675,7 +676,7 @@ int c8_assemble(const char *text) {
 
         c8_set(n++, program.bytes[i].byte);
     }
-    if(c8_verbose > 1 && i & 0x01)
+    if(c8_verbose > 1 && success)
         c8_message("\n");
 
     if(c8_verbose) c8_message("Assembled; %d bytes.\n", program.max_instr - PROG_OFFSET);

--- a/c8asm.c
+++ b/c8asm.c
@@ -38,6 +38,8 @@ typedef enum {
     SYM_OFFSET,
     SYM_DB,
     SYM_DW,
+    SYM_HI,
+    SYM_LO
 } SYMBOL;
 /* List of instruction names. */
 static const char *inst_names[] = {
@@ -237,6 +239,11 @@ scan_start:
                 stepper->sym = SYM_DB;
             else if(!strcmp(stepper->token, "dw"))
                 stepper->sym = SYM_DW;
+            else if(!strcmp(stepper->token, "hi"))
+                stepper->sym = SYM_HI;
+            else if(!strcmp(stepper->token, "lo"))
+                stepper->sym = SYM_LO;
+
             else {
                 stepper->sym = SYM_IDENTIFIER;
                 for(i = 0; i < n_defs; i++) {
@@ -395,6 +402,16 @@ int c8_assemble(const char *text) {
                 emit_b(&stepper,word & 0xFF);
                 nextsym(&stepper);
             } while(stepper.sym == ',');
+        } else if(stepper.sym == SYM_HI)  {
+            nextsym(&stepper);
+            if(stepper.sym != SYM_IDENTIFIER)
+                exit_error("error:%d: identifier expected, found %s\n", stepper.linenum, stepper.token);
+            
+        } else if (stepper.sym == SYM_LO) {
+            nextsym(&stepper);
+            if(stepper.sym != SYM_IDENTIFIER)
+                exit_error("error:%d: identifier expected, found %s\n", stepper.linenum, stepper.token);
+            
         } else if(stepper.sym == SYM_IDENTIFIER) {
             add_label(stepper.token, stepper.linenum);
             expect(&stepper, ':');

--- a/c8asm.c
+++ b/c8asm.c
@@ -401,9 +401,14 @@ static int evaluate_arithmetic_expression(const char * expression, const int lin
 			is_first_char_of_clause=false;
 		} else {
 			bool success = false;
+			char buffer[64];
+			char * bufptr=buffer;
+			while ((*expression) && (!ispunct(*expression) || *expression == '_'))
+				*bufptr++=*expression++;
+			*bufptr='\0';
 			for(int i = 0; i < n_lookup; i++) {
-				size_t len = strlen(lookup[i].label);
-				if(!strncmp(lookup[i].label, expression, len)) {
+				//size_t len = strlen(lookup[i].label);
+				if(!strcmp(lookup[i].label, buffer)) {
 					if(is_prev_figure) {
 						*(++operators.top)='+';
 					}
@@ -412,7 +417,7 @@ static int evaluate_arithmetic_expression(const char * expression, const int lin
 						(*figures.top) = apply_unary_op(*operators.top, *figures.top, linenum);
 						operators.top--;
 					}
-					expression+=len;
+					//expression+=len;
 					success=true;
 					is_first_char_of_clause=false;
 					is_prev_figure=true;
@@ -989,7 +994,7 @@ int c8_assemble(const char *text) {
 			result = get_num(program.bytes[i].expression, (program.bytes[i].type & BITNESS_BITMASK)+1,program.bytes[i].linenum);
 
 		}
-		if (program.bytes[i].type & EMIT8_BITMASK) {
+		if ((program.bytes[i].type != CONTINUED) && (program.bytes[i].type & EMIT8_BITMASK)) {
 			program.bytes[i].byte |= result &0xff;
 		} else {
 			program.bytes[i].byte |= result >> 8;


### PR DESCRIPTION
So I added an arithmetic engine to the assembler. Was a lot harder than I expected. 

I probably changed so much stuff that's it's not really your assembler anymore. Ship of Thesius stuff. I also converted indentation to tabs so you can't even see all the differences in the diffs clearly.

Summary:

- SYM_NUMBER now means it's an arithmetic expression. SYM_IDENTIFIER is also an expression but it needs its own token. 
- I added HI and LO then removed them because `&#ff` and `>>8` are good enough. This is the change that was needed for TRSE code generation. 
- I genericized both emit and get_num so they would work cleanly with the "Expression can be on every immediate" semantics. 
- I also made it accept SYS statements. You wrote that no modern emulator supports it but some like https://github.com/gulrak/cadmium do. 
- I didn't add a modulus operator yet because it conflicts with the binary immediate prefix. Also I'm tired. 
- I replaced all the strdups with strcpys. I think now the program never allocates on the heap. 

I'm making this a pull request because I want you to have a choice about whether to actually pull this considering not much stayed intact. Or whether we should keep this a true fork. This is definitely the version that's going into TRSE regardless because I need to load the high and low bytes of addresses into registers. 